### PR TITLE
Fix git commit loading and replace infinite scroll with Load More button

### DIFF
--- a/claude-maestro/GitTreeView.swift
+++ b/claude-maestro/GitTreeView.swift
@@ -178,13 +178,9 @@ struct GitTreeView: View {
                         }
                     }
 
-                    // Load more sentinel - triggers when scrolled to bottom
+                    // Load more button
                     if graphData.hasMoreCommits && !graphData.commits.isEmpty {
                         loadMoreView
-                            .id(graphData.commits.count)  // Force new view identity when count changes
-                            .onAppear {
-                                Task { await loadMoreCommits() }
-                            }
                     }
                 }
             }
@@ -206,9 +202,13 @@ struct GitTreeView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                Text("Scroll to load more")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                Button(action: {
+                    Task { await loadMoreCommits() }
+                }) {
+                    Text("Load More Commits")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
             }
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Fix infinite scroll not loading more commits after first batch
- Replace infinite scroll with Load More button for git commits

## Test plan
- [ ] Verify Load More button appears when there are more commits available
- [ ] Verify clicking Load More loads additional commits
- [ ] Verify all commits load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)