### PR TITLE
Fix repository URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ A native macOS application that lets you run 1-12 Claude Code (or other AI CLI) 
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/jackwakem/claude-maestro.git
-   cd claude-maestro
+   git clone https://github.com/its-maestro-baby/maestro.git
+   cd maestro
    ```
 
 2. **Open in Xcode:**


### PR DESCRIPTION
## Summary
- Updates the clone URL in README from `jackwakem/claude-maestro` to `its-maestro-baby/maestro`
- Updates the `cd` command to match the new repository name

## Test plan
- [ ] Verify the clone URL in the README points to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)