### PR TITLE
Fix Gemini CLI installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The Swift MCP server (`MaestroMCPServer/`) is built automatically as part of the
 npm install -g @anthropic-ai/claude-code
 
 # Gemini CLI
-npm install -g @anthropic-ai/gemini-cli
+npm install -g @google/gemini-cli
 
 # OpenAI Codex
 npm install -g @openai/codex


### PR DESCRIPTION
## Summary
- Updates the Gemini CLI install command from `@anthropic-ai/gemini-cli` to `@google/gemini-cli`

## Test plan
- [ ] Verify the npm install command is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)