### PR TITLE
Fix session termination when exiting AI CLI

### DIFF
--- a/claude-maestro/TerminalView.swift
+++ b/claude-maestro/TerminalView.swift
@@ -251,6 +251,7 @@ struct EmbeddedTerminalView: NSViewRepresentable {
                     if [ -f ~/.zshrc ]; then source ~/.zshrc 2>/dev/null; fi
                     if [ -f ~/.bash_profile ]; then source ~/.bash_profile 2>/dev/null; fi
                     if [ -f ~/.bashrc ]; then source ~/.bashrc 2>/dev/null; fi
+                    clear
                     cd '\(self.workingDirectory)'
                     \(self.mode.command ?? "echo 'No CLI configured'")
                     """


### PR DESCRIPTION
## Summary
Fixes the issue where terminal sessions become unresponsive and terminate when exiting AI CLI tools (Claude Code, Gemini CLI, etc.) instead of returning to an interactive shell prompt.

## Changes
- Modified `TerminalView.swift` to launch AI CLI sessions in persistent interactive shells
- Changed from using shell `-c` flag (which exits after command completes) to launching an interactive login shell and sending commands via terminal input
- Shell now persists after CLI exits, allowing users to continue working in the same worktree

## Testing
After this fix, users can:
- Exit the AI CLI (e.g., `/exit` in Claude Code)
- Continue using the terminal with a normal shell prompt
- Run additional commands in the worktree directory
- Re-launch the AI CLI if needed

Closes #26