### PR TITLE
Add Nerd Font support for oh-my-zsh icons

### DIFF
--- a/claude-maestro/TerminalView.swift
+++ b/claude-maestro/TerminalView.swift
@@ -119,7 +119,9 @@ struct EmbeddedTerminalView: NSViewRepresentable {
     func makeNSView(context: Context) -> MaestroTerminalView {
         let terminal = MaestroTerminalView(frame: .zero)
         terminal.processDelegate = context.coordinator
-        terminal.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        // Configure terminal font with Nerd Font support for oh-my-zsh icons
+        terminal.font = Self.getTerminalFont()
 
         // Configure terminal colors
         // Use system color for background to match GitTreeView
@@ -195,6 +197,36 @@ struct EmbeddedTerminalView: NSViewRepresentable {
             onServerReady: onServerReady,
             onOutputReceived: onOutputReceived
         )
+    }
+
+    /// Get the terminal font, preferring Nerd Fonts for oh-my-zsh icon support
+    /// Priority: User preference > Installed Nerd Fonts > System monospace font
+    private static func getTerminalFont() -> NSFont {
+        let fontSize: CGFloat = 13
+
+        // Check user preference
+        if let savedFontName = UserDefaults.standard.string(forKey: "terminal-font-name"),
+           let customFont = NSFont(name: savedFontName, size: fontSize) {
+            return customFont
+        }
+
+        // Try common Nerd Fonts in order of popularity
+        let nerdFonts = [
+            "MesloLGS-NF-Regular",      // MesloLGS Nerd Font (popular with oh-my-zsh)
+            "FiraCode-Retina",           // FiraCode Nerd Font
+            "JetBrainsMono-Regular",     // JetBrains Mono Nerd Font
+            "CaskaydiaCove-Regular",     // Cascadia Code Nerd Font
+            "Hack-Regular"               // Hack Nerd Font
+        ]
+
+        for fontName in nerdFonts {
+            if let font = NSFont(name: fontName, size: fontSize) {
+                return font
+            }
+        }
+
+        // Fallback to system monospace font
+        return NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
     }
 
     private func launchTerminal(in terminal: MaestroTerminalView) {


### PR DESCRIPTION
## Summary
Adds automatic Nerd Font detection and support for proper rendering of oh-my-zsh themes with icons and special characters.

## Changes
- **Auto-detect Nerd Fonts**: Automatically finds and uses common Nerd Fonts (MesloLGS NF, FiraCode NF, JetBrains Mono NF, etc.)
- **Custom font preference**: Users can set a custom font via UserDefaults
- **Improved font size**: Increased default from 12pt to 13pt for better readability
- **Graceful fallback**: Falls back to system monospace font if no Nerd Font is available

## Font Priority
1. User-specified font (via `defaults write com.maestro.claude-maestro terminal-font-name "FontName"`)
2. Installed Nerd Fonts (MesloLGS NF, FiraCode, JetBrains Mono, Cascadia Code, Hack)
3. System monospace font

## How to Use
After installing a Nerd Font (e.g., MesloLGS NF from [nerdfonts.com](https://www.nerdfonts.com/)), the terminal will automatically detect and use it. No configuration needed!

### Optional: Set Custom Font
```bash
# Set custom font
defaults write com.maestro.claude-maestro terminal-font-name "MesloLGS-NF-Bold"

# Reset to auto-detect
defaults delete com.maestro.claude-maestro terminal-font-name
```

## Testing
Tested with:
- ✅ MesloLGS Nerd Font + oh-my-zsh Powerlevel10k theme
- ✅ Icons and symbols render correctly
- ✅ Fallback works when no Nerd Font installed

Closes #28