### PR TITLE
Add theme switcher to sidebar

### DIFF
--- a/claude-maestro/AppearanceManager.swift
+++ b/claude-maestro/AppearanceManager.swift
@@ -1,0 +1,64 @@
+//
+//  AppearanceManager.swift
+//  claude-maestro
+//
+//  Created by Maestro on 1/29/2026.
+//
+
+import Combine
+import SwiftUI
+
+enum AppearanceMode: String, CaseIterable, Codable {
+    case light = "Light"
+    case dark = "Dark"
+
+    var icon: String {
+        switch self {
+        case .light: return "sun.max.fill"
+        case .dark: return "moon.fill"
+        }
+    }
+
+    var colorScheme: ColorScheme {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
+
+extension AppearanceMode {
+    var next: AppearanceMode {
+        switch self {
+        case .light: return .dark
+        case .dark: return .light
+        }
+    }
+}
+
+class AppearanceManager: ObservableObject {
+    private static let preferenceKey = "claude-maestro-appearance-mode"
+
+    @Published var currentMode: AppearanceMode {
+        didSet {
+            UserDefaults.standard.set(currentMode.rawValue, forKey: Self.preferenceKey)
+        }
+    }
+
+    var nextMode: AppearanceMode {
+        currentMode.next
+    }
+
+    init() {
+        let saved = UserDefaults.standard.string(forKey: Self.preferenceKey)
+            .flatMap(AppearanceMode.init(rawValue:))
+        self.currentMode = saved ?? .dark
+    }
+
+    func cycleMode() {
+        let allModes = AppearanceMode.allCases
+        let currentIndex = allModes.firstIndex(of: currentMode) ?? 0
+        let nextIndex = (currentIndex + 1) % allModes.count
+        currentMode = allModes[nextIndex]
+    }
+}

--- a/claude-maestro/ContentView.swift
+++ b/claude-maestro/ContentView.swift
@@ -1013,23 +1013,26 @@ class SessionManager: ObservableObject {
 
 struct ContentView: View {
     @StateObject private var manager = SessionManager()
+    @StateObject private var appearanceManager = AppearanceManager()
     @State private var statusMessage: String = "Select a directory to launch Claude Code instances"
     @State private var showBranchSidebar: Bool = false
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            SidebarView(manager: manager)
+            SidebarView(manager: manager, appearanceManager: appearanceManager)
                 .navigationSplitViewColumnWidth(min: 240, ideal: 240, max: 300)
         } detail: {
             MainContentView(
                 manager: manager,
+                appearanceManager: appearanceManager,
                 statusMessage: $statusMessage,
                 showBranchSidebar: $showBranchSidebar,
                 columnVisibility: $columnVisibility
             )
         }
         .navigationSplitViewStyle(.balanced)
+        .preferredColorScheme(appearanceManager.currentMode.colorScheme)
     }
 }
 
@@ -1037,6 +1040,7 @@ struct ContentView: View {
 
 struct MainContentView: View {
     @ObservedObject var manager: SessionManager
+    @ObservedObject var appearanceManager: AppearanceManager
     @Binding var statusMessage: String
     @Binding var showBranchSidebar: Bool
     @Binding var columnVisibility: NavigationSplitViewVisibility

--- a/claude-maestro/SidebarView.swift
+++ b/claude-maestro/SidebarView.swift
@@ -26,6 +26,7 @@ enum SidebarTab: String, CaseIterable {
 
 struct SidebarView: View {
     @ObservedObject var manager: SessionManager
+    @ObservedObject var appearanceManager: AppearanceManager
     @State private var selectedTab: SidebarTab = .configuration
 
     var body: some View {
@@ -67,7 +68,7 @@ struct SidebarView: View {
             // Tab Content
             switch selectedTab {
             case .configuration:
-                ConfigurationSidebarContent(manager: manager)
+                ConfigurationSidebarContent(manager: manager, appearanceManager: appearanceManager)
             case .processes:
                 ProcessSidebarView(manager: manager)
             }
@@ -83,6 +84,7 @@ struct SidebarView: View {
 
 struct ConfigurationSidebarContent: View {
     @ObservedObject var manager: SessionManager
+    @ObservedObject var appearanceManager: AppearanceManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -261,6 +263,12 @@ struct ConfigurationSidebarContent: View {
 
                     // Quick Actions Section
                     QuickActionsSection()
+
+                    Divider()
+                        .padding(.horizontal, 8)
+
+                    // Theme Switcher Section
+                    ThemeSwitcherSection(appearanceManager: appearanceManager)
                 }
                 .padding(.bottom, 8)
             }
@@ -1062,6 +1070,29 @@ struct ClaudeMDSection: View {
     }
 }
 
+// MARK: - Theme Switcher Section
+
+struct ThemeSwitcherSection: View {
+    @ObservedObject var appearanceManager: AppearanceManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Appearance")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 0) {
+                ThemeSwitcherButton(appearanceManager: appearanceManager)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(8)
+            .background(Color(NSColor.windowBackgroundColor))
+            .cornerRadius(8)
+        }
+        .padding(.horizontal, 8)
+    }
+}
+
 #Preview {
-    SidebarView(manager: SessionManager())
+    SidebarView(manager: SessionManager(), appearanceManager: AppearanceManager())
 }

--- a/claude-maestro/ThemeSwitcherButton.swift
+++ b/claude-maestro/ThemeSwitcherButton.swift
@@ -1,0 +1,83 @@
+//
+//  ThemeSwitcherButton.swift
+//  claude-maestro
+//
+//  Created by Maestro on 1/29/2026.
+//
+
+import SwiftUI
+
+struct ThemeSwitcherButton: View {
+    @ObservedObject var appearanceManager: AppearanceManager
+    @State private var isPressed = false
+
+    var body: some View {
+        Button {
+            // Haptic feedback
+            NSHapticFeedbackManager.defaultPerformer.perform(
+                .alignment,
+                performanceTime: .default
+            )
+
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isPressed = true
+            }
+
+            appearanceManager.cycleMode()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    isPressed = false
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: appearanceManager.nextMode.icon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(iconColor)
+                    .frame(width: 16)
+
+                Text("Switch to \(appearanceManager.nextMode.rawValue)")
+                    .font(.caption)
+                    .fontWeight(.medium)
+
+                Spacer()
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(backgroundColor)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(borderColor, lineWidth: 0.5)
+            )
+            .scaleEffect(isPressed ? 0.97 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .help("Switch to \(appearanceManager.nextMode.rawValue) mode")
+        .accessibilityLabel("Switch to \(appearanceManager.nextMode.rawValue) mode")
+    }
+
+    private var backgroundColor: Color {
+        Color(NSColor.windowBackgroundColor)
+    }
+
+    private var iconColor: Color {
+        switch appearanceManager.nextMode {
+        case .light: return Color.orange
+        case .dark: return Color.blue
+        }
+    }
+
+    private var borderColor: Color {
+        iconColor.opacity(0.2)
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var manager = AppearanceManager()
+    ThemeSwitcherButton(appearanceManager: manager)
+        .padding()
+}


### PR DESCRIPTION
## Summary
Adds a theme switcher button to the sidebar that allows users to toggle between light and dark appearance modes without changing system-wide settings.

## Changes
- **AppearanceManager.swift**: Handles theme state management and persistence via UserDefaults
- **ThemeSwitcherButton.swift**: SwiftUI component for the theme toggle button
- **ContentView.swift**: Applies selected theme via `.preferredColorScheme()`
- **SidebarView.swift**: Integrates button into sidebar appearance section

## Features
- Single-click theme switching (no need to change system settings)
- Shows next mode icon and text (sun for light, moon for dark)
- Persists user preference across app launches
- Matches sidebar design with rectangular buttons and subtle styling
- Haptic feedback and proper accessibility labels

## Design
The button follows existing sidebar patterns:
- Rectangular shape with 6px rounded corners
- System background colors for consistency
- Icon colors: orange for light mode, blue for dark mode
- Subtle border using icon color at 20% opacity
- Press animation with scale effect

## Testing
- [x] Build succeeds with no warnings
- [x] Single click switches theme immediately
- [x] Theme preference persists after app restart
- [x] Visual consistency with other sidebar elements
- [x] Accessibility labels and tooltips work correctly

Closes #30