### PR TITLE
Add Project and Local scope support for plugin installation

### DIFF
--- a/claude-maestro/MarketplaceManager.swift
+++ b/claude-maestro/MarketplaceManager.swift
@@ -696,7 +696,11 @@ class MarketplaceManager: ObservableObject {
     }
 
     /// Install a plugin from marketplace
-    func installPlugin(_ plugin: MarketplacePlugin, scope: InstallScope) async throws -> InstalledPlugin {
+    /// - Parameters:
+    ///   - plugin: The marketplace plugin to install
+    ///   - scope: Installation scope (user, project, or local)
+    ///   - projectPath: Required for project/local scopes - the path to the project directory
+    func installPlugin(_ plugin: MarketplacePlugin, scope: InstallScope, projectPath: String? = nil) async throws -> InstalledPlugin {
         // Determine installation path based on scope
         let installPath: String
         switch scope {
@@ -704,10 +708,19 @@ class MarketplaceManager: ObservableObject {
             installPath = FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".claude/plugins/\(plugin.id)").path
         case .project:
-            // Would need current project path
-            throw MarketplaceError.installationError("Project scope requires a project path")
+            guard let projectPath = projectPath, !projectPath.isEmpty else {
+                throw MarketplaceError.installationError("Project scope requires a project path")
+            }
+            // Project scope: install to .claude/plugins/ in the project directory (committed to git)
+            installPath = URL(fileURLWithPath: projectPath)
+                .appendingPathComponent(".claude/plugins/\(plugin.id)").path
         case .local:
-            throw MarketplaceError.installationError("Local scope requires a project path")
+            guard let projectPath = projectPath, !projectPath.isEmpty else {
+                throw MarketplaceError.installationError("Local scope requires a project path")
+            }
+            // Local scope: install to .claude.local/plugins/ in the project directory (gitignored)
+            installPath = URL(fileURLWithPath: projectPath)
+                .appendingPathComponent(".claude.local/plugins/\(plugin.id)").path
         }
 
         // Determine the source path for symlinking


### PR DESCRIPTION
## Summary

This PR implements full support for **Project** and **Local** installation scopes in the plugin marketplace, which were previously unimplemented (threw errors).

### Changes

**MarketplaceManager.swift:**
- Added optional `projectPath` parameter to `installPlugin()`
- **Project scope**: Installs plugins to `<projectPath>/.claude/plugins/` (committed to git, shared with collaborators)
- **Local scope**: Installs plugins to `<projectPath>/.claude.local/plugins/` (gitignored, personal use)
- User scope remains unchanged (`~/.claude/plugins/`)

**MarketplaceBrowserView.swift:**
- Updated `PluginInstallSheetV2` to show a directory picker when Project/Local scope is selected
- **Auto-detection**: Pre-fills the project path from `SkillManager.currentProjectPath` (the directory selected at the bottom of Maestro)
- Visual feedback: Shows "(auto-detected)" label, green checkmark, and green border when using the detected path
- Manual override: Users can still click the folder button to select a different directory

### Screenshots

When selecting Project or Local scope, the install dialog now shows the auto-detected project directory with visual confirmation.

### Test Plan

- [x] Select "User" scope → Plugin installs to `~/.claude/plugins/` (unchanged behavior)
- [x] Select "Project" scope with detected project → Plugin installs to `.claude/plugins/`
- [x] Select "Local" scope with detected project → Plugin installs to `.claude.local/plugins/`
- [x] Click folder button to override detected path → New path is used
- [x] Install button disabled until directory selected (when required)