### PR TITLE
Add resizable panel dividers for terminal grid

### DIFF
--- a/claude-maestro/PanelSizeManager.swift
+++ b/claude-maestro/PanelSizeManager.swift
@@ -1,0 +1,207 @@
+// PanelSizeManager.swift
+// claude-maestro
+//
+// Manages and persists panel size ratios for the resizable terminal grid.
+
+import SwiftUI
+import Combine
+
+/// Manages the size ratios for resizable panels in the terminal grid.
+/// Persists sizes to UserDefaults and handles grid reconfiguration.
+final class PanelSizeManager: ObservableObject {
+    private static let storageKey = "claude-maestro-panel-sizes"
+
+    /// Position of the horizontal divider between rows (0.0-1.0 ratio)
+    @Published var horizontalSplit: CGFloat = 0.5
+
+    /// Position of vertical dividers for each row (0.0-1.0 ratios)
+    /// Index 0 = first row's column divider, Index 1 = second row's column divider, etc.
+    @Published var verticalSplits: [CGFloat] = []
+
+    /// Additional vertical split positions for rows with 3+ columns
+    /// Maps row index to array of split positions
+    @Published var multiColumnSplits: [Int: [CGFloat]] = [:]
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        load()
+        setupAutoSave()
+    }
+
+    // MARK: - Persistence
+
+    private func setupAutoSave() {
+        // Debounce saves to avoid excessive disk writes during dragging
+        $horizontalSplit
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $verticalSplits
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $multiColumnSplits
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+    }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: Self.storageKey),
+              let stored = try? JSONDecoder().decode(StoredPanelSizes.self, from: data) else {
+            // Initialize with defaults
+            initializeDefaults()
+            return
+        }
+
+        horizontalSplit = stored.horizontalSplit
+        verticalSplits = stored.verticalSplits
+        multiColumnSplits = stored.multiColumnSplits
+    }
+
+    private func save() {
+        let stored = StoredPanelSizes(
+            version: 1,
+            horizontalSplit: horizontalSplit,
+            verticalSplits: verticalSplits,
+            multiColumnSplits: multiColumnSplits
+        )
+
+        if let data = try? JSONEncoder().encode(stored) {
+            UserDefaults.standard.set(data, forKey: Self.storageKey)
+        }
+    }
+
+    private func initializeDefaults() {
+        horizontalSplit = 0.5
+        verticalSplits = [0.5, 0.5, 0.5]  // Support up to 3 rows
+        multiColumnSplits = [:]
+    }
+
+    // MARK: - Public API
+
+    /// Resets all panel sizes to equal distribution
+    func reset() {
+        horizontalSplit = 0.5
+        verticalSplits = verticalSplits.map { _ in 0.5 }
+        multiColumnSplits = multiColumnSplits.mapValues { $0.map { _ in 0.5 } }
+        save()
+    }
+
+    /// Ensures we have enough vertical split values for the given number of rows
+    func ensureCapacity(forRows rowCount: Int) {
+        while verticalSplits.count < rowCount {
+            verticalSplits.append(0.5)
+        }
+    }
+
+    /// Returns the vertical split position for a given row, creating one if needed
+    func verticalSplit(forRow row: Int) -> Binding<CGFloat> {
+        ensureCapacity(forRows: row + 1)
+
+        return Binding(
+            get: { [weak self] in
+                guard let self = self, row < self.verticalSplits.count else { return 0.5 }
+                return self.verticalSplits[row]
+            },
+            set: { [weak self] newValue in
+                guard let self = self, row < self.verticalSplits.count else { return }
+                self.verticalSplits[row] = newValue
+            }
+        )
+    }
+
+    /// Returns column widths as ratios for a given row with the specified number of columns
+    /// For 2 columns: uses single vertical split
+    /// For 3+ columns: uses multiColumnSplits
+    func columnWidths(forRow row: Int, columnCount: Int) -> [CGFloat] {
+        switch columnCount {
+        case 1:
+            return [1.0]
+        case 2:
+            ensureCapacity(forRows: row + 1)
+            let split = verticalSplits[safe: row] ?? 0.5
+            return [split, 1.0 - split]
+        default:
+            // For 3+ columns, use evenly distributed widths
+            // or stored multi-column splits if available
+            if let splits = multiColumnSplits[row], splits.count == columnCount - 1 {
+                var widths: [CGFloat] = []
+                var remaining: CGFloat = 1.0
+                for split in splits {
+                    let width = remaining * split
+                    widths.append(width)
+                    remaining -= width
+                }
+                widths.append(remaining)
+                return widths
+            } else {
+                // Equal distribution
+                let width = 1.0 / CGFloat(columnCount)
+                return Array(repeating: width, count: columnCount)
+            }
+        }
+    }
+
+    /// Called when grid configuration changes (sessions added/removed)
+    /// Resets splits that are no longer valid
+    func onGridReconfigured(newRows: Int, columnsPerRow: [Int]) {
+        // Reset to defaults when configuration changes significantly
+        // This prevents awkward sizing when going from 2x2 to 1x3, etc.
+        ensureCapacity(forRows: newRows)
+
+        // Clean up multiColumnSplits for rows that no longer exist
+        for rowIndex in multiColumnSplits.keys where rowIndex >= newRows {
+            multiColumnSplits.removeValue(forKey: rowIndex)
+        }
+    }
+}
+
+// MARK: - Storage Model
+
+private struct StoredPanelSizes: Codable {
+    let version: Int
+    let horizontalSplit: CGFloat
+    let verticalSplits: [CGFloat]
+    let multiColumnSplits: [Int: [CGFloat]]
+
+    enum CodingKeys: String, CodingKey {
+        case version, horizontalSplit, verticalSplits, multiColumnSplits
+    }
+
+    init(version: Int, horizontalSplit: CGFloat, verticalSplits: [CGFloat], multiColumnSplits: [Int: [CGFloat]]) {
+        self.version = version
+        self.horizontalSplit = horizontalSplit
+        self.verticalSplits = verticalSplits
+        self.multiColumnSplits = multiColumnSplits
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        horizontalSplit = try container.decode(CGFloat.self, forKey: .horizontalSplit)
+        verticalSplits = try container.decode([CGFloat].self, forKey: .verticalSplits)
+
+        // Decode multiColumnSplits with string keys (JSON limitation)
+        let stringKeyedSplits = try container.decodeIfPresent([String: [CGFloat]].self, forKey: .multiColumnSplits) ?? [:]
+        multiColumnSplits = Dictionary(uniqueKeysWithValues: stringKeyedSplits.compactMap { key, value in
+            guard let intKey = Int(key) else { return nil }
+            return (intKey, value)
+        })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(horizontalSplit, forKey: .horizontalSplit)
+        try container.encode(verticalSplits, forKey: .verticalSplits)
+
+        // Encode multiColumnSplits with string keys (JSON limitation)
+        let stringKeyedSplits = Dictionary(uniqueKeysWithValues: multiColumnSplits.map { ("\($0.key)", $0.value) })
+        try container.encode(stringKeyedSplits, forKey: .multiColumnSplits)
+    }
+}
+

--- a/claude-maestro/ResizableDivider.swift
+++ b/claude-maestro/ResizableDivider.swift
@@ -1,0 +1,156 @@
+// ResizableDivider.swift
+// claude-maestro
+//
+// Draggable divider component for resizing adjacent panels in the terminal grid.
+
+import SwiftUI
+import AppKit
+
+/// A draggable divider that allows resizing of adjacent panels.
+/// Supports both horizontal (between rows) and vertical (between columns) orientations.
+struct ResizableDivider: View {
+    enum Orientation {
+        case horizontal  // Divides rows (drag up/down)
+        case vertical    // Divides columns (drag left/right)
+    }
+
+    let orientation: Orientation
+    @Binding var position: CGFloat  // 0.0-1.0 ratio
+    let containerSize: CGFloat      // Total size in the relevant dimension
+
+    let minPosition: CGFloat = 0.15
+    let maxPosition: CGFloat = 0.85
+
+    @State private var isDragging = false
+    @State private var isHovering = false
+
+    /// Width/height of the divider hit target area
+    private let dividerThickness: CGFloat = 8
+
+    /// Width of the visible divider line when hovering/dragging
+    private let visibleLineThickness: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Invisible hit target area
+                Color.clear
+
+                // Visible divider line (only shown on hover/drag)
+                if isHovering || isDragging {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(Color.accentColor.opacity(isDragging ? 0.8 : 0.5))
+                        .frame(
+                            width: orientation == .vertical ? visibleLineThickness : nil,
+                            height: orientation == .horizontal ? visibleLineThickness : nil
+                        )
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 1, coordinateSpace: .named("resizableContainer"))
+                    .onChanged { value in
+                        isDragging = true
+                        updatePosition(with: value, geometry: geometry)
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
+            .onTapGesture(count: 2) {
+                // Double-click resets to center (50%)
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    position = 0.5
+                }
+            }
+            .onHover { hovering in
+                isHovering = hovering
+                updateCursor(hovering: hovering)
+            }
+        }
+        .frame(
+            width: orientation == .vertical ? dividerThickness : nil,
+            height: orientation == .horizontal ? dividerThickness : nil
+        )
+    }
+
+    private func updatePosition(with value: DragGesture.Value, geometry: GeometryProxy) {
+        // Use absolute position in the container coordinate space
+        let absolutePosition: CGFloat
+        switch orientation {
+        case .horizontal:
+            absolutePosition = value.location.y / containerSize
+        case .vertical:
+            absolutePosition = value.location.x / containerSize
+        }
+
+        // Clamp to valid range
+        position = min(maxPosition, max(minPosition, absolutePosition))
+    }
+
+    private func updateCursor(hovering: Bool) {
+        if hovering {
+            switch orientation {
+            case .horizontal:
+                NSCursor.resizeUpDown.push()
+            case .vertical:
+                NSCursor.resizeLeftRight.push()
+            }
+        } else {
+            NSCursor.pop()
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var horizontalPosition: CGFloat = 0.5
+        @State private var verticalPosition: CGFloat = 0.5
+
+        var body: some View {
+            GeometryReader { geometry in
+                VStack(spacing: 0) {
+                    // Top row
+                    HStack(spacing: 0) {
+                        Color.blue.opacity(0.3)
+                            .frame(width: geometry.size.width * verticalPosition)
+
+                        ResizableDivider(
+                            orientation: .vertical,
+                            position: $verticalPosition,
+                            containerSize: geometry.size.width
+                        )
+
+                        Color.green.opacity(0.3)
+                    }
+                    .frame(height: geometry.size.height * horizontalPosition)
+
+                    ResizableDivider(
+                        orientation: .horizontal,
+                        position: $horizontalPosition,
+                        containerSize: geometry.size.height
+                    )
+
+                    // Bottom row
+                    HStack(spacing: 0) {
+                        Color.orange.opacity(0.3)
+                            .frame(width: geometry.size.width * verticalPosition)
+
+                        ResizableDivider(
+                            orientation: .vertical,
+                            position: $verticalPosition,
+                            containerSize: geometry.size.width
+                        )
+
+                        Color.purple.opacity(0.3)
+                    }
+                }
+            }
+            .frame(width: 600, height: 400)
+        }
+    }
+
+    return PreviewWrapper()
+}

--- a/claude-maestro/TerminalView.swift
+++ b/claude-maestro/TerminalView.swift
@@ -738,121 +738,42 @@ struct TerminalSessionView: View {
     @State private var showMissingToolAlert = false
     @State private var missingToolName: String = ""
 
+    /// Threshold width below which header collapses to compact mode
+    private let compactHeaderThreshold: CGFloat = 400
+
     var body: some View {
         VStack(spacing: 0) {
-            // Status bar with controls
-            HStack(spacing: 6) {
-                // Status indicator
-                Group {
-                    if #available(macOS 14.0, *) {
-                        Image(systemName: status.icon)
-                            .foregroundColor(status.color)
-                            .symbolEffect(.pulse, isActive: status == .working)
-                            .font(.caption)
-                    } else {
-                        Image(systemName: status.icon)
-                            .foregroundColor(status.color)
-                            .font(.caption)
-                    }
-                }
+            // Responsive status bar with controls
+            GeometryReader { headerGeometry in
+                let isCompact = headerGeometry.size.width < compactHeaderThreshold
 
-                // Direct mode picker (replaces cycling toggle)
-                CompactModePicker(selectedMode: $mode, isDisabled: shouldLaunch)
-
-                // Session label
-                Text("\(mode.rawValue) #\(session.id)")
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .foregroundColor(mode.color)
-
-                // MCP server selector (AI modes only)
-                if mode.isAIMode {
-                    MCPSelector(
-                        sessionId: session.id,
-                        mcpManager: MCPServerManager.shared,
-                        isDisabled: shouldLaunch
-                    )
-
-                    // Skills & Commands selector
-                    CapabilitySelector(
-                        sessionId: session.id,
-                        skillManager: SkillManager.shared,
-                        commandManager: CommandManager.shared,
-                        isDisabled: shouldLaunch
-                    )
-                }
-
-                // Agent status (only when terminal launched)
-                if shouldLaunch, let state = agentState {
-                    HStack(spacing: 4) {
-                        StatusPill(state: state.state)
-                        Text(state.message)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-
-                Spacer()
-
-                // Branch selector (only when terminal not launched)
-                if gitManager.isGitRepo && !shouldLaunch {
-                    BranchSelector(
-                        gitManager: gitManager,
-                        selectedBranch: $assignedBranch
-                    )
-                }
-
-                // Branch label (after terminal launched)
-                if gitManager.isGitRepo && shouldLaunch {
-                    HStack(spacing: 2) {
-                        Image(systemName: "arrow.triangle.branch")
-                            .font(.caption2)
-                        Text(assignedBranch ?? "Current")
-                            .font(.caption2)
-                    }
-                    .foregroundColor(.secondary)
-                }
-
-                // Launch Terminal button (before terminal launched)
-                if !shouldLaunch {
-                    Button(action: {
-                        // Check if CLI tool is available before launching
-                        if mode.isAIMode && !mode.isToolAvailable() {
-                            missingToolName = mode.command ?? "unknown"
-                            showMissingToolAlert = true
+                HStack(spacing: 6) {
+                    // Status indicator (always visible)
+                    Group {
+                        if #available(macOS 14.0, *) {
+                            Image(systemName: status.icon)
+                                .foregroundColor(status.color)
+                                .symbolEffect(.pulse, isActive: status == .working)
+                                .font(.caption)
                         } else {
-                            onLaunchTerminal()
+                            Image(systemName: status.icon)
+                                .foregroundColor(status.color)
+                                .font(.caption)
                         }
-                    }) {
-                        HStack(spacing: 2) {
-                            Image(systemName: "play.fill")
-                            Text("Launch")
-                        }
-                        .font(.caption2)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .tint(mode.color)
-                }
 
-                // Status label
-                Text(status.label)
-                    .font(.caption2)
-                    .foregroundColor(status.color)
-
-                // Close button
-                Button(action: onClose) {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.secondary)
-                        .font(.caption)
+                    if isCompact {
+                        // Compact mode: hamburger menu with options
+                        compactHeaderContent
+                    } else {
+                        // Full mode: all controls visible
+                        fullHeaderContent
+                    }
                 }
-                .buttonStyle(.plain)
-                .help("Close terminal")
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .frame(height: 28)
             .background(status.color.opacity(0.15))
 
             // Terminal content area
@@ -1008,5 +929,182 @@ struct TerminalSessionView: View {
         if let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    // MARK: - Header Content Views
+
+    /// Full header content shown at normal widths
+    @ViewBuilder
+    private var fullHeaderContent: some View {
+        // Direct mode picker
+        CompactModePicker(selectedMode: $mode, isDisabled: shouldLaunch)
+
+        // Session label
+        Text("\(mode.rawValue) #\(session.id)")
+            .font(.caption)
+            .fontWeight(.medium)
+            .foregroundColor(mode.color)
+
+        // MCP server selector (AI modes only)
+        if mode.isAIMode {
+            MCPSelector(
+                sessionId: session.id,
+                mcpManager: MCPServerManager.shared,
+                isDisabled: shouldLaunch
+            )
+
+            // Skills & Commands selector
+            CapabilitySelector(
+                sessionId: session.id,
+                skillManager: SkillManager.shared,
+                commandManager: CommandManager.shared,
+                isDisabled: shouldLaunch
+            )
+        }
+
+        // Agent status (only when terminal launched)
+        if shouldLaunch, let state = agentState {
+            HStack(spacing: 4) {
+                StatusPill(state: state.state)
+                Text(state.message)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+
+        Spacer()
+
+        // Branch selector (only when terminal not launched)
+        if gitManager.isGitRepo && !shouldLaunch {
+            BranchSelector(
+                gitManager: gitManager,
+                selectedBranch: $assignedBranch
+            )
+        }
+
+        // Branch label (after terminal launched)
+        if gitManager.isGitRepo && shouldLaunch {
+            HStack(spacing: 2) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.caption2)
+                Text(assignedBranch ?? "Current")
+                    .font(.caption2)
+            }
+            .foregroundColor(.secondary)
+        }
+
+        // Launch Terminal button (before terminal launched)
+        if !shouldLaunch {
+            Button(action: {
+                if mode.isAIMode && !mode.isToolAvailable() {
+                    missingToolName = mode.command ?? "unknown"
+                    showMissingToolAlert = true
+                } else {
+                    onLaunchTerminal()
+                }
+            }) {
+                HStack(spacing: 2) {
+                    Image(systemName: "play.fill")
+                    Text("Launch")
+                }
+                .font(.caption2)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .tint(mode.color)
+        }
+
+        // Status label
+        Text(status.label)
+            .font(.caption2)
+            .foregroundColor(status.color)
+
+        // Close button
+        Button(action: onClose) {
+            Image(systemName: "xmark.circle.fill")
+                .foregroundColor(.secondary)
+                .font(.caption)
+        }
+        .buttonStyle(.plain)
+        .help("Close terminal")
+    }
+
+    /// Compact header content shown at narrow widths with hamburger menu
+    @ViewBuilder
+    private var compactHeaderContent: some View {
+        // Mode icon
+        Image(systemName: mode.icon)
+            .font(.caption)
+            .foregroundColor(mode.color)
+
+        // Session number
+        Text("#\(session.id)")
+            .font(.caption)
+            .fontWeight(.medium)
+            .foregroundColor(mode.color)
+
+        Spacer()
+
+        // Launch button (before terminal launched)
+        if !shouldLaunch {
+            Button(action: {
+                if mode.isAIMode && !mode.isToolAvailable() {
+                    missingToolName = mode.command ?? "unknown"
+                    showMissingToolAlert = true
+                } else {
+                    onLaunchTerminal()
+                }
+            }) {
+                Image(systemName: "play.fill")
+                    .font(.caption2)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .tint(mode.color)
+        }
+
+        // Hamburger menu with options
+        Menu {
+            // Mode options
+            Text("Mode").font(.headline)
+            ForEach(TerminalMode.allCases, id: \.self) { modeOption in
+                Button {
+                    mode = modeOption
+                } label: {
+                    Label(modeOption.rawValue, systemImage: modeOption.icon)
+                }
+                .disabled(shouldLaunch)
+            }
+
+            Divider()
+
+            // Branch info
+            if gitManager.isGitRepo {
+                Label(assignedBranch ?? "Current Branch", systemImage: "arrow.triangle.branch")
+            }
+
+            Divider()
+
+            // Close
+            Button(action: onClose) {
+                Label("Close", systemImage: "xmark.circle")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+
+        // Close button
+        Button(action: onClose) {
+            Image(systemName: "xmark.circle.fill")
+                .foregroundColor(.secondary)
+                .font(.caption)
+        }
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
## Summary
- Add draggable dividers between session panels to allow users to resize the width/height of each panel in the 2x2 (or any configuration) grid
- Horizontal divider between rows, independent vertical dividers per row
- Panel sizes persist across app restarts
- Double-click divider to reset to 50%, or use Reset Layout button
- Responsive header collapses to hamburger menu at narrow widths

## Features
- **ResizableDivider.swift**: Reusable draggable divider component with:
  - Horizontal/vertical orientation support
  - Hover/drag visual feedback (divider line appears on interaction)
  - Cursor changes to resize arrows on hover
  - Double-click to reset to center

- **PanelSizeManager.swift**: State management with:
  - UserDefaults persistence (debounced saves)
  - Per-row vertical splits
  - Codable storage with version number for future migration

- **Responsive header**: Terminal session header now adapts to narrow widths with hamburger menu containing mode selection, branch info, and close option

## Test plan
- [ ] Launch app with 4 sessions to get 2x2 grid
- [ ] Drag horizontal divider between rows - verify both rows resize
- [ ] Drag vertical dividers - verify columns resize independently per row
- [ ] Double-click a divider - verify it resets to 50%
- [ ] Click Reset Layout button - verify all dividers reset
- [ ] Close and reopen app - verify sizes persist
- [ ] Resize window to narrow width - verify header collapses gracefully