### PR TITLE
Bundle MaestroMCPServer in app for DMG releases

### DIFF
--- a/claude-maestro.xcodeproj/project.pbxproj
+++ b/claude-maestro.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 				CB2098EC2F0CBC2600779863 /* Sources */,
 				CB2098ED2F0CBC2600779863 /* Frameworks */,
 				CB2098EE2F0CBC2600779863 /* Resources */,
+				CB2099202F0E000000779863 /* Build MaestroMCPServer */,
 			);
 			buildRules = (
 			);
@@ -123,6 +124,27 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		CB2099202F0E000000779863 /* Build MaestroMCPServer */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build MaestroMCPServer";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "# Build MaestroMCPServer and bundle it inside the app\nset -e\n\nMCP_SERVER_DIR=\"${SRCROOT}/MaestroMCPServer\"\nRESOURCES_DIR=\"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Resources\"\n\necho \"Building MaestroMCPServer...\"\ncd \"${MCP_SERVER_DIR}\"\n/usr/bin/swift build -c release\n\necho \"Creating Resources directory...\"\nmkdir -p \"${RESOURCES_DIR}\"\n\necho \"Copying MaestroMCPServer binary to app bundle...\"\ncp \"${MCP_SERVER_DIR}/.build/release/MaestroMCPServer\" \"${RESOURCES_DIR}/\"\nchmod +x \"${RESOURCES_DIR}/MaestroMCPServer\"\n\necho \"MaestroMCPServer bundled successfully!\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		CB2098EC2F0CBC2600779863 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -171,7 +193,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -234,7 +256,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/claude-maestro/MCPServerManager.swift
+++ b/claude-maestro/MCPServerManager.swift
@@ -162,18 +162,24 @@ class MCPServerManager: ObservableObject {
 
     /// Get path to native Swift MCP server binary
     private func getNativeMCPServerPath() -> String? {
-        // First, check in the app bundle (for release builds)
-        if let bundlePath = Bundle.main.executableURL?.deletingLastPathComponent()
-            .appendingPathComponent("MaestroMCPServer").path,
+        // First, check Application Support (stable path, copied from bundle on first launch)
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        if let appSupportPath = appSupport?.appendingPathComponent("Claude Maestro/MaestroMCPServer").path,
+           FileManager.default.isExecutableFile(atPath: appSupportPath) {
+            return appSupportPath
+        }
+
+        // Check in app bundle Resources folder (fallback for first launch before copy completes)
+        if let bundlePath = Bundle.main.url(forResource: "MaestroMCPServer", withExtension: nil)?.path,
            FileManager.default.isExecutableFile(atPath: bundlePath) {
             return bundlePath
         }
 
-        // Check in Application Support (for development)
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        if let devPath = appSupport?.appendingPathComponent("Claude Maestro/MaestroMCPServer").path,
-           FileManager.default.isExecutableFile(atPath: devPath) {
-            return devPath
+        // Check in app bundle MacOS folder (legacy location)
+        if let bundlePath = Bundle.main.executableURL?.deletingLastPathComponent()
+            .appendingPathComponent("MaestroMCPServer").path,
+           FileManager.default.isExecutableFile(atPath: bundlePath) {
+            return bundlePath
         }
 
         // Check in DerivedData/Build/Products for development builds

--- a/claude-maestro/claude_maestroApp.swift
+++ b/claude-maestro/claude_maestroApp.swift
@@ -48,6 +48,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Setup MaestroMCPServer from bundle to Application Support
+        setupMaestroMCPServer()
+
         // Check for orphaned processes on startup
         Task {
             let orphanCount = await processRegistry.orphanedAgentCount()
@@ -55,6 +58,71 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 print("⚠️ Found \(orphanCount) orphaned agent process(es) from previous sessions")
                 print("   Use the Processes sidebar to view and terminate them")
             }
+        }
+    }
+
+    /// Copy MaestroMCPServer from app bundle to Application Support if needed.
+    /// This ensures the MCP server is available for Claude Code sessions even when
+    /// running from a downloaded DMG release.
+    private func setupMaestroMCPServer() {
+        let fm = FileManager.default
+
+        // Find the bundled MaestroMCPServer in Resources
+        guard let bundledPath = Bundle.main.url(forResource: "MaestroMCPServer", withExtension: nil) else {
+            print("ℹ️ MaestroMCPServer not found in app bundle (development build)")
+            return
+        }
+
+        // Get Application Support destination
+        guard let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            print("⚠️ Could not find Application Support directory")
+            return
+        }
+
+        let maestroDir = appSupportURL.appendingPathComponent("Claude Maestro")
+        let destPath = maestroDir.appendingPathComponent("MaestroMCPServer")
+
+        do {
+            // Create directory if needed
+            if !fm.fileExists(atPath: maestroDir.path) {
+                try fm.createDirectory(at: maestroDir, withIntermediateDirectories: true)
+            }
+
+            // Check if we need to copy (doesn't exist or bundle version is newer)
+            var shouldCopy = !fm.fileExists(atPath: destPath.path)
+
+            if !shouldCopy {
+                // Compare modification dates - copy if bundle is newer
+                let bundledAttrs = try fm.attributesOfItem(atPath: bundledPath.path)
+                let destAttrs = try fm.attributesOfItem(atPath: destPath.path)
+
+                if let bundledDate = bundledAttrs[.modificationDate] as? Date,
+                   let destDate = destAttrs[.modificationDate] as? Date {
+                    shouldCopy = bundledDate > destDate
+                }
+            }
+
+            if shouldCopy {
+                // Remove existing file if present
+                if fm.fileExists(atPath: destPath.path) {
+                    try fm.removeItem(at: destPath)
+                }
+
+                // Copy from bundle
+                try fm.copyItem(at: bundledPath, to: destPath)
+
+                // Ensure executable permissions
+                try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destPath.path)
+
+                print("✅ MaestroMCPServer installed to Application Support")
+
+                // Refresh MCPServerManager to use the new Application Support path
+                Task { @MainActor in
+                    MCPServerManager.shared.checkServerAvailability()
+                }
+            }
+        } catch {
+            print("⚠️ Failed to setup MaestroMCPServer: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bundle MaestroMCPServer binary inside the app (Contents/Resources/)
- On first launch, copy from bundle to Application Support
- Enables MCP server to work for users downloading DMG releases

## Problem
The previous build phase only copied MaestroMCPServer to Application Support during build, which meant:
- DMG releases didn't include the binary
- Users downloading releases saw "Maestro MCP: Not Available"
- Agent status reporting didn't work

## Solution
1. **Build phase** copies binary to app bundle's Resources folder
2. **First-launch setup** copies from bundle → `~/Library/Application Support/Claude Maestro/`
3. **MCPServerManager** prioritizes Application Support (stable path), falls back to bundle

This ensures the MCP server works whether building from source OR running from a downloaded DMG.

## Test plan
- [x] Clean build from scratch
- [x] Verify MaestroMCPServer binary is in `Maestro.app/Contents/Resources/`
- [x] Verify first-launch copies to Application Support
- [x] Verify MCP server is available when running the app

Fixes #44

Thanks to @hubciorz for the feedback on the original approach!