### PR TITLE
Rename from maestro-linux to maestro

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "maestro-linux"
+name = "maestro"
 version = "0.1.0"
-description = "Maestro — Multi-session AI orchestrator for Linux"
+description = "Maestro — Multi-session AI orchestrator"
 authors = ["lliWcWill"]
 edition = "2021"
 
 [lib]
-name = "maestro_linux_lib"
+name = "maestro_lib"
 crate-type = ["lib"]
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,5 +12,5 @@ fn main() {
         }
     }
 
-    maestro_linux_lib::run()
+    maestro_lib::run()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Maestro",
   "version": "0.1.0",
-  "identifier": "com.maestro.linux",
+  "identifier": "com.maestro.app",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary
- Update package name: maestro-linux → maestro
- Update lib name: maestro_linux_lib → maestro_lib
- Update identifier: com.maestro.linux → com.maestro.app
- Remove "for Linux" from description

Cross-platform naming cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)