### PR TITLE
Add automatic release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create-release.outputs.id }}
+      release_upload_url: ${{ steps.create-release.outputs.upload_url }}
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: get-version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get-version.outputs.version }}-${{ github.run_number }}
+          release_name: Maestro v${{ steps.get-version.outputs.version }} (Build ${{ github.run_number }})
+          draft: false
+          prerelease: false
+          body: |
+            ## Maestro v${{ steps.get-version.outputs.version }}
+
+            Automated release from main branch.
+
+            ### Downloads
+            - **macOS**: Download the `.dmg` file
+            - **Windows**: Download the `.msi` or `.exe` installer
+            - **Linux**: Download the `.deb` or `.AppImage` file
+
+  build:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            target: universal-apple-darwin
+            name: macOS
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: Windows
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            name: Linux
+
+    runs-on: ${{ matrix.platform }}
+    name: Build (${{ matrix.name }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        shell: bash
+        run: |
+          rm -f package-lock.json
+          npm install
+
+      - name: Build MCP server
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" = "macos-latest" ]; then
+            cargo build --release -p maestro-mcp-server --target aarch64-apple-darwin
+            cargo build --release -p maestro-mcp-server --target x86_64-apple-darwin
+            mkdir -p maestro-mcp-server/target/release
+            lipo -create -output maestro-mcp-server/target/release/maestro-mcp-server \
+              target/aarch64-apple-darwin/release/maestro-mcp-server \
+              target/x86_64-apple-darwin/release/maestro-mcp-server
+          elif [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            cargo build --release -p maestro-mcp-server
+            mkdir -p maestro-mcp-server/target/release
+            cp target/release/maestro-mcp-server.exe maestro-mcp-server/target/release/
+          else
+            cargo build --release -p maestro-mcp-server
+            mkdir -p maestro-mcp-server/target/release
+            cp target/release/maestro-mcp-server maestro-mcp-server/target/release/
+          fi
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+
+      - name: Upload macOS DMG
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/Maestro_${{ needs.create-release.outputs.version }}_universal.dmg
+          asset_name: Maestro_${{ needs.create-release.outputs.version }}_macOS_universal.dmg
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows MSI
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: src-tauri/target/release/bundle/msi/Maestro_${{ needs.create-release.outputs.version }}_x64_en-US.msi
+          asset_name: Maestro_${{ needs.create-release.outputs.version }}_Windows_x64.msi
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows NSIS
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: src-tauri/target/release/bundle/nsis/Maestro_${{ needs.create-release.outputs.version }}_x64-setup.exe
+          asset_name: Maestro_${{ needs.create-release.outputs.version }}_Windows_x64_setup.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Linux DEB
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: src-tauri/target/release/bundle/deb/maestro_${{ needs.create-release.outputs.version }}_amd64.deb
+          asset_name: Maestro_${{ needs.create-release.outputs.version }}_Linux_amd64.deb
+          asset_content_type: application/octet-stream
+
+      - name: Upload Linux AppImage
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: src-tauri/target/release/bundle/appimage/maestro_${{ needs.create-release.outputs.version }}_amd64.AppImage
+          asset_name: Maestro_${{ needs.create-release.outputs.version }}_Linux_amd64.AppImage
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- Adds `release.yml` workflow that triggers on push to main
- Creates GitHub release with version tag (e.g., `v0.1.0-42`)
- Uploads all platform binaries to the release:
  - macOS: `.dmg` (universal binary)
  - Windows: `.msi` and `.exe` installer
  - Linux: `.deb` and `.AppImage`

## Changes
- `release.yml`: New workflow for automatic releases
- `build.yml`: Now only runs on PRs (avoids duplicate builds)

## How it works
1. PR merged → push to main triggers release.yml
2. Creates a draft-less release with auto-generated tag
3. Builds all 3 platforms in parallel
4. Uploads artifacts directly to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)