### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to release workflow to fix "Resource not accessible by integration" error when creating releases

## Test plan
- [ ] Re-run the release workflow after merge and verify releases are created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)