### PR TITLE
Fix Windows console windows spawning for background processes

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -6,6 +6,7 @@ use tauri::{AppHandle, State};
 
 use crate::core::session_manager::SessionManager;
 use crate::core::status_server::StatusServer;
+use crate::core::windows_process::TokioCommandExt;
 use crate::core::{BackendCapabilities, BackendType, ProcessManager, PtyError, SessionProcessTree};
 
 /// Backend information returned to the frontend.
@@ -263,6 +264,7 @@ pub async fn check_cli_available(command: String) -> Result<bool, String> {
     {
         let output = tokio::process::Command::new("where.exe")
             .arg(&command)
+            .hide_console_window()
             .output()
             .await
             .map_err(|e| format!("Failed to check CLI: {}", e))?;

--- a/src-tauri/src/core/marketplace_manager.rs
+++ b/src-tauri/src/core/marketplace_manager.rs
@@ -15,6 +15,7 @@ use tokio::process::Command;
 
 use super::marketplace_error::{MarketplaceError, MarketplaceResult};
 use super::marketplace_models::*;
+use super::windows_process::TokioCommandExt;
 
 /// Official Anthropic Claude Code marketplace.
 const OFFICIAL_MARKETPLACE_NAME: &str = "Claude Code Official";
@@ -330,6 +331,7 @@ impl MarketplaceManager {
         let output = Command::new("git")
             .args(["clone", "--depth", "1", repo_url])
             .arg(target_dir)
+            .hide_console_window()
             .output()
             .await
             .map_err(|e| MarketplaceError::CloneError(format!("Failed to run git: {}", e)))?;
@@ -369,6 +371,7 @@ impl MarketplaceManager {
                 repo_url,
             ])
             .arg(&temp_dir)
+            .hide_console_window()
             .output()
             .await
             .map_err(|e| MarketplaceError::CloneError(format!("Failed to run git clone: {}", e)))?;
@@ -386,6 +389,7 @@ impl MarketplaceManager {
         let output = Command::new("git")
             .args(["sparse-checkout", "set", "--no-cone", subpath])
             .current_dir(&temp_dir)
+            .hide_console_window()
             .output()
             .await
             .map_err(|e| {
@@ -405,6 +409,7 @@ impl MarketplaceManager {
         let output = Command::new("git")
             .args(["checkout"])
             .current_dir(&temp_dir)
+            .hide_console_window()
             .output()
             .await
             .map_err(|e| MarketplaceError::CloneError(format!("Failed to run git checkout: {}", e)))?;

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -12,6 +12,7 @@ pub mod process_tree;
 pub mod session_manager;
 pub mod status_server;
 pub mod terminal_backend;
+pub mod windows_process;
 pub mod worktree_manager;
 pub mod xterm_backend;
 

--- a/src-tauri/src/core/process_manager.rs
+++ b/src-tauri/src/core/process_manager.rs
@@ -464,9 +464,11 @@ impl ProcessManager {
         #[cfg(windows)]
         {
             use std::process::Command;
+            use super::windows_process::StdCommandExt;
             // Use taskkill to terminate process tree
             let result = Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .hide_console_window()
                 .output();
 
             if let Err(e) = result {

--- a/src-tauri/src/core/process_tree.rs
+++ b/src-tauri/src/core/process_tree.rs
@@ -231,9 +231,11 @@ pub async fn kill_process(pid: u32, session_root_pids: &[i32]) -> Result<(), Pro
     #[cfg(windows)]
     {
         use std::process::Command;
+        use super::windows_process::StdCommandExt;
 
         let result = Command::new("taskkill")
             .args(["/PID", &pid.to_string(), "/F"])
+            .hide_console_window()
             .output();
 
         match result {

--- a/src-tauri/src/core/vte_backend.rs
+++ b/src-tauri/src/core/vte_backend.rs
@@ -578,8 +578,10 @@ impl TerminalBackend for VteBackend {
         #[cfg(windows)]
         {
             use std::process::Command;
+            use super::windows_process::StdCommandExt;
             let _ = Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .hide_console_window()
                 .output();
         }
 

--- a/src-tauri/src/core/windows_process.rs
+++ b/src-tauri/src/core/windows_process.rs
@@ -1,0 +1,58 @@
+//! Windows-specific process spawning utilities.
+//!
+//! Provides extension traits to apply CREATE_NO_WINDOW flag to process commands,
+//! preventing visible console windows from spawning for background operations.
+//!
+//! On Windows, spawning a process via `std::process::Command` or `tokio::process::Command`
+//! without the `CREATE_NO_WINDOW` flag causes a visible console window to appear for
+//! each subprocess. This module provides a clean, cross-platform way to hide these
+//! windows for background operations like git commands and process termination.
+
+/// The CREATE_NO_WINDOW flag for Windows process creation (0x08000000).
+/// When set, the new process does not inherit or create a console window.
+#[cfg(windows)]
+pub const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Extension trait for `std::process::Command` to hide console windows on Windows.
+pub trait StdCommandExt {
+    /// Configures the command to not create a visible console window on Windows.
+    /// On non-Windows platforms, this is a no-op.
+    fn hide_console_window(&mut self) -> &mut Self;
+}
+
+/// Extension trait for `tokio::process::Command` to hide console windows on Windows.
+pub trait TokioCommandExt {
+    /// Configures the command to not create a visible console window on Windows.
+    /// On non-Windows platforms, this is a no-op.
+    fn hide_console_window(&mut self) -> &mut Self;
+}
+
+#[cfg(windows)]
+impl StdCommandExt for std::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        use std::os::windows::process::CommandExt;
+        self.creation_flags(CREATE_NO_WINDOW)
+    }
+}
+
+#[cfg(not(windows))]
+impl StdCommandExt for std::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        self // No-op on non-Windows
+    }
+}
+
+#[cfg(windows)]
+impl TokioCommandExt for tokio::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        use std::os::windows::process::CommandExt;
+        self.creation_flags(CREATE_NO_WINDOW)
+    }
+}
+
+#[cfg(not(windows))]
+impl TokioCommandExt for tokio::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        self // No-op on non-Windows
+    }
+}

--- a/src-tauri/src/core/xterm_backend.rs
+++ b/src-tauri/src/core/xterm_backend.rs
@@ -408,8 +408,10 @@ impl TerminalBackend for XtermPassthroughBackend {
         #[cfg(windows)]
         {
             use std::process::Command;
+            use super::windows_process::StdCommandExt;
             let result = Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .hide_console_window()
                 .output();
 
             if let Err(e) = result {

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -3,6 +3,7 @@ use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
 use super::error::GitError;
+use crate::core::windows_process::TokioCommandExt;
 
 /// Captured stdout/stderr from a completed git subprocess.
 ///
@@ -57,7 +58,8 @@ impl Git {
             .args(args)
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("LC_ALL", "C")
-            .kill_on_drop(true);
+            .kill_on_drop(true)
+            .hide_console_window();
 
         let command_str = format!("git -C {} {}", self.repo_path.display(), args.join(" "));
 


### PR DESCRIPTION
## Summary

Fixes #76 - Terminal windows spawning and accumulating on Windows.

**Root Cause:** On Windows, spawning processes via `std::process::Command` or `tokio::process::Command` without the `CREATE_NO_WINDOW` flag causes a visible console window to appear for each subprocess. This affected:
- Git operations (clone, fetch, status, etc.)
- CLI availability checks (`where.exe`)
- Process termination (`taskkill`)

**Solution:** Added a new `windows_process` module with extension traits that apply the `CREATE_NO_WINDOW` (0x08000000) flag on Windows. The `.hide_console_window()` method is a no-op on non-Windows platforms.

## Changes

- **New:** `src-tauri/src/core/windows_process.rs` - Extension traits for hiding console windows
- **Updated:** 8 files to use `.hide_console_window()` on all background process spawning

## Test plan

- [ ] Build on Windows: `cargo build --release`
- [ ] Launch the app and verify no console windows appear during:
  - Git operations
  - Session termination
  - CLI availability checks
- [ ] Verify no regressions on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)