### PR TITLE
Revert: Display MCP server status in sidebar (#89)

### DIFF
--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -46,8 +46,6 @@ pub struct StatusServerInfo {
     pub port: u16,
     pub status_url: String,
     pub instance_id: String,
-    /// Path to the maestro-mcp-server binary, if found.
-    pub mcp_binary_path: Option<String>,
 }
 
 /// Creates a stable hash of a project path for use in store filenames.
@@ -242,29 +240,24 @@ pub async fn remove_session_status(
     Ok(())
 }
 
-/// Gets the status server info (URL, port, instance ID, and binary path).
+/// Gets the status server info (URL, port, instance ID).
 ///
 /// This is needed by the frontend when writing MCP configs so the
-/// MCP server knows where to POST status updates. Also used by the
-/// sidebar to display MCP server status.
+/// MCP server knows where to POST status updates.
 #[tauri::command]
 pub async fn get_status_server_info(
     status_server: State<'_, Arc<StatusServer>>,
 ) -> Result<StatusServerInfo, String> {
     let registered = status_server.registered_sessions().await;
-    let mcp_binary_path = mcp_config_writer::find_maestro_mcp_path()
-        .map(|p| p.to_string_lossy().into_owned());
     log::info!(
-        "get_status_server_info: instance_id={}, registered_sessions={:?}, mcp_binary={:?}",
+        "get_status_server_info: instance_id={}, registered_sessions={:?}",
         status_server.instance_id(),
-        registered,
-        mcp_binary_path
+        registered
     );
     Ok(StatusServerInfo {
         port: status_server.port(),
         status_url: status_server.status_url(),
         instance_id: status_server.instance_id().to_string(),
-        mcp_binary_path,
     })
 }
 

--- a/src-tauri/src/core/mcp_config_writer.rs
+++ b/src-tauri/src/core/mcp_config_writer.rs
@@ -20,7 +20,7 @@ use crate::commands::mcp::McpCustomServer;
 /// 3. Development: relative to src-tauri/target/debug or release
 /// 4. macOS Application Support (~Library/Application Support/Claude Maestro/)
 /// 5. Linux local share (~/.local/share/maestro/)
-pub fn find_maestro_mcp_path() -> Option<PathBuf> {
+fn find_maestro_mcp_path() -> Option<PathBuf> {
     // Determine the binary name based on platform
     #[cfg(target_os = "windows")]
     let binary_name = "maestro-mcp-server.exe";

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -45,7 +45,7 @@ import { MarketplaceBrowser } from "@/components/marketplace";
 import { McpServerEditorModal } from "@/components/mcp";
 import { ClaudeMdEditorModal } from "@/components/claudemd";
 import { TerminalSettingsModal } from "@/components/terminal/TerminalSettingsModal";
-import { getStatusServerInfo, type McpCustomServer, type StatusServerInfo } from "@/lib/mcp";
+import type { McpCustomServer } from "@/lib/mcp";
 import { checkClaudeMd, type ClaudeMdStatus } from "@/lib/claudemd";
 
 type SidebarTab = "config" | "processes";
@@ -701,74 +701,24 @@ function StatusSection() {
 /* ── 5. Maestro MCP ── */
 
 function MaestroMCPSection() {
-  const [serverInfo, setServerInfo] = useState<StatusServerInfo | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const fetchServerInfo = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const info = await getStatusServerInfo();
-      setServerInfo(info);
-      setError(null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to get server info");
-      setServerInfo(null);
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchServerInfo();
-  }, [fetchServerInfo]);
-
-  // Truncate path for display
-  const truncatePath = (path: string | null): string => {
-    if (!path) return "Not found";
-    const maxLen = 30;
-    if (path.length <= maxLen) return path;
-    // Show last part of path
-    const parts = path.replace(/\\/g, "/").split("/");
-    const filename = parts[parts.length - 1];
-    if (filename.length >= maxLen - 3) {
-      return `...${filename.slice(-(maxLen - 3))}`;
-    }
-    return `...${path.slice(-(maxLen - 3))}`;
-  };
-
-  const isRunning = serverInfo !== null && !error;
-  const statusColor = isRunning ? "bg-maestro-green" : "bg-maestro-red";
-  const statusText = error ? "Error" : isRunning ? `Running on port ${serverInfo.port}` : "Unavailable";
-  const iconColor = isRunning ? "text-maestro-green" : "text-maestro-red";
-
   return (
     <div className={cardClass}>
       <SectionHeader
         icon={Server}
         label="Maestro MCP"
-        iconColor={iconColor}
+        iconColor="text-maestro-green"
         right={
-          <button
-            type="button"
-            className="rounded p-0.5 hover:bg-maestro-border/40"
-            onClick={fetchServerInfo}
-            disabled={isRefreshing}
-            title="Refresh status"
-          >
-            <RefreshCw
-              size={12}
-              className={`text-maestro-muted ${isRefreshing ? "animate-spin" : ""}`}
-            />
+          <button type="button" className="rounded p-0.5 hover:bg-maestro-border/40">
+            <RefreshCw size={12} className="text-maestro-muted" />
           </button>
         }
       />
-      <div className="flex items-center gap-2 px-1 py-1" title={error ?? undefined}>
-        <span className={`h-2 w-2 shrink-0 rounded-full ${statusColor}`} />
-        <span className="text-xs text-maestro-text font-medium">{statusText}</span>
+      <div className="flex items-center gap-2 px-1 py-1">
+        <span className="h-2 w-2 shrink-0 rounded-full bg-maestro-green" />
+        <span className="text-xs text-maestro-text font-medium">Available</span>
       </div>
-      <div className="pl-5 text-[10px] text-maestro-muted truncate" title={serverInfo?.mcpBinaryPath ?? undefined}>
-        {truncatePath(serverInfo?.mcpBinaryPath ?? null)}
+      <div className="pl-5 text-[10px] text-maestro-muted truncate">
+        /usr/lib/maestro...MCPServer
       </div>
     </div>
   );

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -188,25 +188,3 @@ export async function saveCustomMcpServer(server: McpCustomServer): Promise<void
 export async function deleteCustomMcpServer(serverId: string): Promise<void> {
   return invoke("delete_custom_mcp_server", { serverId });
 }
-
-/**
- * Status server information returned from the backend.
- */
-export interface StatusServerInfo {
-  /** Port the status server is listening on. */
-  port: number;
-  /** Full URL for posting status updates. */
-  statusUrl: string;
-  /** Instance ID for this Maestro app instance. */
-  instanceId: string;
-  /** Path to the maestro-mcp-server binary, if found. */
-  mcpBinaryPath: string | null;
-}
-
-/**
- * Gets the status server info (URL, port, instance ID, and binary path).
- * Used to display MCP server status in the sidebar.
- */
-export async function getStatusServerInfo(): Promise<StatusServerInfo> {
-  return invoke<StatusServerInfo>("get_status_server_info");
-}


### PR DESCRIPTION
## Summary

Reverts PR #89 due to CI/CD failure:
```
ENOENT: no such file or directory, stat 'src-tauri/target/release/bundle/deb/maestro_0.1.0_amd64.deb'
```

The feature will need to be re-submitted after fixing the build issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)