### PR TITLE
Fix Windows terminal not starting (#93)

### DIFF
--- a/src-tauri/src/core/process_manager.rs
+++ b/src-tauri/src/core/process_manager.rs
@@ -207,11 +207,17 @@ impl ProcessManager {
         #[cfg(unix)]
         cmd.arg("-l"); // Login shell for proper env on Unix
 
-        // Set TERM for proper terminal emulation.
+        // Set TERM for proper terminal emulation on Unix.
         // xterm-256color is the standard for modern terminal emulators and enables:
         // - Proper cursor positioning and line editing
         // - 256-color support
         // - Correct handling of escape sequences
+        //
+        // On Windows, we don't set TERM because:
+        // - Windows ConPTY handles terminal emulation internally
+        // - cmd.exe/PowerShell don't use the TERM variable
+        // - Setting TERM can cause shell initialization issues (Issue #93)
+        #[cfg(unix)]
         cmd.env("TERM", "xterm-256color");
 
         // Inject MAESTRO_SESSION_ID automatically (used by MCP status server)


### PR DESCRIPTION
## Summary
- Makes `TERM=xterm-256color` conditional on Unix only via `#[cfg(unix)]`
- Fixes Windows 11 terminals hanging indefinitely on startup
- Preserves the terminal rendering fix from #95 for Unix/macOS

## Problem
PR #95 added `TERM=xterm-256color` to fix terminal rendering corruption on Unix/macOS. However, this broke Windows because:
- Windows cmd.exe/PowerShell don't use the `TERM` variable
- Windows ConPTY handles terminal emulation internally
- Setting TERM caused shell initialization to hang

## Solution
Added `#[cfg(unix)]` to only set TERM on Unix platforms, where it's needed for proper terminal emulation.

Fixes #93

## Test plan
- [ ] Test on Windows 11 with cmd.exe - terminal should start normally
- [ ] Test on Windows 11 with PowerShell - terminal should start normally
- [ ] Test on macOS - terminal should work as before (TERM=xterm-256color)
- [ ] Verify Claude Code CLI launches properly on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)