### PR TITLE
feat: Add user-configurable CLI flags for sessions

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -44,6 +44,7 @@ import { QuickActionsManager } from "@/components/quickactions/QuickActionsManag
 import { MarketplaceBrowser } from "@/components/marketplace";
 import { McpServerEditorModal } from "@/components/mcp";
 import { ClaudeMdEditorModal } from "@/components/claudemd";
+import { CliSettingsModal } from "@/components/terminal/CliSettingsModal";
 import { TerminalSettingsModal } from "@/components/terminal/TerminalSettingsModal";
 import type { McpCustomServer } from "@/lib/mcp";
 import { checkClaudeMd, type ClaudeMdStatus } from "@/lib/claudemd";
@@ -1346,6 +1347,7 @@ function AppearanceSection({
 }) {
   const isDark = theme !== "light";
   const [showTerminalSettings, setShowTerminalSettings] = useState(false);
+  const [showCliSettings, setShowCliSettings] = useState(false);
 
   return (
     <>
@@ -1374,10 +1376,21 @@ function AppearanceSection({
           <Wrench size={14} className="text-maestro-muted" />
           <span>Terminal Settings</span>
         </button>
+        <button
+          type="button"
+          onClick={() => setShowCliSettings(true)}
+          className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-xs text-maestro-text transition-colors hover:bg-maestro-border/40"
+        >
+          <Zap size={14} className="text-maestro-accent" />
+          <span>CLI Settings</span>
+        </button>
       </div>
 
       {showTerminalSettings && (
         <TerminalSettingsModal onClose={() => setShowTerminalSettings(false)} />
+      )}
+      {showCliSettings && (
+        <CliSettingsModal onClose={() => setShowCliSettings(false)} />
       )}
     </>
   );

--- a/src/components/terminal/CliSettingsModal.tsx
+++ b/src/components/terminal/CliSettingsModal.tsx
@@ -1,0 +1,209 @@
+import { AlertTriangle, RotateCcw, Terminal, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useCliSettingsStore } from "@/stores/useCliSettingsStore";
+import { AI_CLI_CONFIG, buildCliCommand, type CliAiMode } from "@/lib/terminal";
+
+interface CliSettingsModalProps {
+  onClose: () => void;
+}
+
+/** The AI modes that support CLI flags. */
+const CLI_MODES: CliAiMode[] = ["Claude", "Gemini", "Codex"];
+
+/** Mode display configuration */
+const MODE_CONFIG: Record<CliAiMode, { color: string; bgColor: string; skipFlagName: string }> = {
+  Claude: {
+    color: "text-maestro-orange",
+    bgColor: "bg-maestro-orange/20",
+    skipFlagName: "--dangerously-skip-permissions",
+  },
+  Gemini: {
+    color: "text-maestro-accent",
+    bgColor: "bg-maestro-accent/20",
+    skipFlagName: "--yolo",
+  },
+  Codex: {
+    color: "text-maestro-green",
+    bgColor: "bg-maestro-green/20",
+    skipFlagName: "--dangerously-bypass-approvals-and-sandbox",
+  },
+};
+
+/**
+ * Modal for managing CLI settings for each AI mode.
+ * Allows configuring flags like --dangerously-skip-permissions and custom flags.
+ */
+export function CliSettingsModal({ onClose }: CliSettingsModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [activeMode, setActiveMode] = useState<CliAiMode>("Claude");
+
+  const { flags, setSkipPermissions, setCustomFlags, resetModeToDefaults, resetAllToDefaults } =
+    useCliSettingsStore();
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const currentFlags = flags[activeMode];
+  const previewCommand = buildCliCommand(activeMode, currentFlags);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div
+        ref={modalRef}
+        className="w-full max-w-lg rounded-lg border border-maestro-border bg-maestro-bg shadow-2xl"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-maestro-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Terminal size={16} className="text-maestro-accent" />
+            <h2 className="text-sm font-semibold text-maestro-text">CLI Settings</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 hover:bg-maestro-border/40"
+          >
+            <X size={16} className="text-maestro-muted" />
+          </button>
+        </div>
+
+        {/* Mode Tabs */}
+        <div className="flex border-b border-maestro-border">
+          {CLI_MODES.map((mode) => {
+            const config = MODE_CONFIG[mode];
+            const isActive = activeMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setActiveMode(mode)}
+                className={`flex-1 px-4 py-2.5 text-xs font-medium transition-colors ${
+                  isActive
+                    ? `${config.bgColor} ${config.color} border-b-2 border-current`
+                    : "text-maestro-muted hover:text-maestro-text hover:bg-maestro-border/20"
+                }`}
+              >
+                {mode}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Content */}
+        <div className="space-y-4 p-4">
+          {/* Skip Permissions Toggle */}
+          <section>
+            <div className="mb-2 flex items-center gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-maestro-muted">
+                Permissions
+              </h3>
+              <span className="rounded bg-maestro-red/20 px-1.5 py-0.5 text-[10px] font-medium text-maestro-red">
+                Security
+              </span>
+            </div>
+            <div className="rounded-lg border border-maestro-border bg-maestro-card p-3">
+              <label className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={currentFlags.skipPermissions}
+                  onChange={(e) => setSkipPermissions(activeMode, e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded border-maestro-border accent-maestro-accent"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-maestro-text">
+                      Skip Permission Prompts
+                    </span>
+                    {currentFlags.skipPermissions && (
+                      <span className="flex items-center gap-1 rounded bg-maestro-red/20 px-1.5 py-0.5 text-[10px] font-medium text-maestro-red">
+                        <AlertTriangle size={10} />
+                        Risk
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 text-xs text-maestro-muted">
+                    Adds <code className="rounded bg-maestro-border/40 px-1">{MODE_CONFIG[activeMode].skipFlagName}</code> flag.
+                    The CLI will not ask for confirmation before running commands.
+                  </p>
+                </div>
+              </label>
+            </div>
+          </section>
+
+          {/* Custom Flags */}
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-maestro-muted">
+              Custom Flags
+            </h3>
+            <div className="rounded-lg border border-maestro-border bg-maestro-card p-3">
+              <input
+                type="text"
+                value={currentFlags.customFlags}
+                onChange={(e) => setCustomFlags(activeMode, e.target.value)}
+                placeholder="e.g., --verbose --model opus"
+                className="w-full rounded border border-maestro-border bg-maestro-bg px-3 py-2 text-sm text-maestro-text placeholder:text-maestro-muted/50 focus:border-maestro-accent focus:outline-none"
+              />
+              <p className="mt-2 text-xs text-maestro-muted">
+                Additional flags to pass to the {activeMode} CLI. Separate multiple flags with spaces.
+              </p>
+            </div>
+          </section>
+
+          {/* Command Preview */}
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-maestro-muted">
+              Command Preview
+            </h3>
+            <div className="rounded-lg border border-maestro-border bg-maestro-card p-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-maestro-muted">$</span>
+                <code className="flex-1 font-mono text-sm text-maestro-text">
+                  {previewCommand ?? AI_CLI_CONFIG[activeMode].command}
+                </code>
+              </div>
+            </div>
+          </section>
+
+          {/* Actions */}
+          <div className="flex items-center justify-between border-t border-maestro-border pt-4">
+            <button
+              type="button"
+              onClick={resetAllToDefaults}
+              className="flex items-center gap-1 rounded px-3 py-1.5 text-xs font-medium text-maestro-muted hover:bg-maestro-border/40 hover:text-maestro-text"
+            >
+              <RotateCcw size={12} />
+              Reset All
+            </button>
+            <button
+              type="button"
+              onClick={() => resetModeToDefaults(activeMode)}
+              className="flex items-center gap-1 rounded px-3 py-1.5 text-xs font-medium text-maestro-muted hover:bg-maestro-border/40 hover:text-maestro-text"
+            >
+              <RotateCcw size={12} />
+              Reset {activeMode}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -16,6 +16,7 @@ import {
 import {
   AI_CLI_CONFIG,
   assignSessionBranch,
+  buildCliCommand,
   checkCliAvailable,
   createSession,
   killSession,
@@ -23,6 +24,7 @@ import {
   waitForTerminalReady,
   writeStdin,
 } from "@/lib/terminal";
+import { useCliSettingsStore } from "@/stores/useCliSettingsStore";
 import { cleanupSessionWorktree, prepareSessionWorktree } from "@/lib/worktreeManager";
 import { useTerminalKeyboard } from "@/hooks/useTerminalKeyboard";
 import { useMcpStore } from "@/stores/useMcpStore";
@@ -530,8 +532,12 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
             // Brief delay for shell to initialize
             await new Promise((resolve) => setTimeout(resolve, 100));
 
+            // Build CLI command with user-configured flags
+            const cliFlags = useCliSettingsStore.getState().getFlags(slot.mode);
+            const cliCommand = buildCliCommand(slot.mode, cliFlags);
+
             // Send CLI launch command
-            await writeStdin(sessionId, `${cliConfig.command}\r`);
+            await writeStdin(sessionId, `${cliCommand}\r`);
 
             // Brief delay for CLI initialization.
             // With session-specific MCP server names (maestro-1, maestro-2, etc.),

--- a/src/stores/useCliSettingsStore.ts
+++ b/src/stores/useCliSettingsStore.ts
@@ -1,0 +1,159 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+import { create } from "zustand";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import type { AiMode } from "@/lib/terminal";
+
+// --- Types ---
+
+/** CLI flags configuration for a single AI mode. */
+export type AiModeCliFlags = {
+  /** Whether to include --dangerously-skip-permissions flag. */
+  skipPermissions: boolean;
+  /** Space-separated additional custom flags. */
+  customFlags: string;
+};
+
+/** CLI flags configuration for all AI modes. */
+export type CliFlagsConfig = Record<Exclude<AiMode, "Plain">, AiModeCliFlags>;
+
+/** Read-only slice of the CLI settings store; persisted to disk. */
+type CliSettingsState = {
+  flags: CliFlagsConfig;
+};
+
+/** Actions for managing CLI settings. */
+type CliSettingsActions = {
+  /** Update the skipPermissions flag for a mode. */
+  setSkipPermissions: (mode: Exclude<AiMode, "Plain">, value: boolean) => void;
+  /** Update the custom flags for a mode. */
+  setCustomFlags: (mode: Exclude<AiMode, "Plain">, value: string) => void;
+  /** Reset all settings for a specific mode to defaults. */
+  resetModeToDefaults: (mode: Exclude<AiMode, "Plain">) => void;
+  /** Reset all settings to defaults. */
+  resetAllToDefaults: () => void;
+  /** Get the effective flags for a mode. */
+  getFlags: (mode: Exclude<AiMode, "Plain">) => AiModeCliFlags;
+};
+
+// --- Default Settings ---
+
+const DEFAULT_MODE_FLAGS: AiModeCliFlags = {
+  skipPermissions: false,
+  customFlags: "",
+};
+
+const DEFAULT_FLAGS: CliFlagsConfig = {
+  Claude: { ...DEFAULT_MODE_FLAGS },
+  Gemini: { ...DEFAULT_MODE_FLAGS },
+  Codex: { ...DEFAULT_MODE_FLAGS },
+};
+
+// --- Tauri LazyStore-backed StateStorage adapter ---
+
+/**
+ * Singleton LazyStore instance for CLI settings.
+ * Stored separately from other store files to keep concerns separate.
+ */
+const lazyStore = new LazyStore("cli-settings.json");
+
+/**
+ * Zustand-compatible StateStorage adapter backed by the Tauri plugin-store.
+ */
+const tauriStorage: StateStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    try {
+      const value = await lazyStore.get<string>(name);
+      return value ?? null;
+    } catch (err) {
+      console.error(`tauriStorage.getItem("${name}") failed:`, err);
+      return null;
+    }
+  },
+  setItem: async (name: string, value: string): Promise<void> => {
+    try {
+      await lazyStore.set(name, value);
+      await lazyStore.save();
+    } catch (err) {
+      console.error(`tauriStorage.setItem("${name}") failed:`, err);
+      throw err;
+    }
+  },
+  removeItem: async (name: string): Promise<void> => {
+    try {
+      await lazyStore.delete(name);
+      await lazyStore.save();
+    } catch (err) {
+      console.error(`tauriStorage.removeItem("${name}") failed:`, err);
+      throw err;
+    }
+  },
+};
+
+// --- Store ---
+
+/**
+ * Global store for CLI settings.
+ *
+ * Manages per-AI-mode CLI flags with persistence.
+ * Flags are automatically applied when launching CLI sessions.
+ */
+export const useCliSettingsStore = create<CliSettingsState & CliSettingsActions>()(
+  persist(
+    (set, get) => ({
+      flags: DEFAULT_FLAGS,
+
+      setSkipPermissions: (mode, value) => {
+        set({
+          flags: {
+            ...get().flags,
+            [mode]: {
+              ...get().flags[mode],
+              skipPermissions: value,
+            },
+          },
+        });
+      },
+
+      setCustomFlags: (mode, value) => {
+        set({
+          flags: {
+            ...get().flags,
+            [mode]: {
+              ...get().flags[mode],
+              customFlags: value,
+            },
+          },
+        });
+      },
+
+      resetModeToDefaults: (mode) => {
+        set({
+          flags: {
+            ...get().flags,
+            [mode]: { ...DEFAULT_MODE_FLAGS },
+          },
+        });
+      },
+
+      resetAllToDefaults: () => {
+        set({
+          flags: {
+            Claude: { ...DEFAULT_MODE_FLAGS },
+            Gemini: { ...DEFAULT_MODE_FLAGS },
+            Codex: { ...DEFAULT_MODE_FLAGS },
+          },
+        });
+      },
+
+      getFlags: (mode) => {
+        return get().flags[mode] ?? DEFAULT_MODE_FLAGS;
+      },
+    }),
+    {
+      name: "maestro-cli-settings",
+      storage: createJSONStorage(() => tauriStorage),
+      partialize: (state) => ({ flags: state.flags }),
+      version: 1,
+    }
+  )
+);


### PR DESCRIPTION
## Summary

Adds the ability for users to configure CLI flags that are automatically appended when launching AI sessions. This allows users to enable "YOLO mode" (skip permissions) and add custom flags per AI mode.

- Adds new CLI Settings modal accessible from sidebar
- Per-mode flag configuration (Claude, Gemini, Codex)
- Toggle for skip-permissions with correct flag per CLI:
  - Claude: `--dangerously-skip-permissions`
  - Gemini: `--yolo`
  - Codex: `--dangerously-bypass-approvals-and-sandbox`
- Custom flags text input for additional flags
- Live command preview
- Persistent settings via Tauri LazyStore

## New Files
- `src/stores/useCliSettingsStore.ts` - Zustand store with persistence
- `src/components/terminal/CliSettingsModal.tsx` - Settings modal UI

## Modified Files
- `src/lib/terminal.ts` - Added `buildCliCommand()` helper and CLI config updates
- `src/components/sidebar/Sidebar.tsx` - Added CLI Settings button
- `src/components/terminal/TerminalGrid.tsx` - Uses configured flags on launch

## Test plan
- [ ] Open app and click "CLI Settings" in sidebar
- [ ] Toggle skip-permissions for Claude, verify preview shows `claude --dangerously-skip-permissions`
- [ ] Switch to Gemini tab, toggle skip-permissions, verify preview shows `gemini --yolo`
- [ ] Switch to Codex tab, toggle skip-permissions, verify preview shows `codex --dangerously-bypass-approvals-and-sandbox`
- [ ] Add custom flags, verify they appear in preview
- [ ] Launch a session, verify the command includes configured flags
- [ ] Close and reopen app, verify settings persist

Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)