### PR TITLE
Add repository scan button to Git Settings modal

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,8 @@ pub fn run() {
             commands::git::git_set_remote_url,
             commands::git::git_get_default_branch,
             commands::git::git_set_default_branch,
+            commands::git::is_git_repository,
+            commands::git::detect_repositories,
             // Session commands (new)
             commands::session::get_sessions,
             commands::session::create_session,

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -417,7 +417,7 @@ function GitRepositorySection() {
       </div>
 
       {showSettings && (
-        <GitSettingsModal repoPath={repoPath} onClose={() => setShowSettings(false)} />
+        <GitSettingsModal repoPath={repoPath} tabId={activeTab?.id ?? ""} onClose={() => setShowSettings(false)} />
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- Adds a "Repository Discovery" section to the Git Settings modal
- Allows users to recursively scan the workspace for nested git repositories
- Displays found repos with name, current branch, and remote URL
- Updates the workspace store so discovered repos appear in the PreLaunchCard dropdown

## Changes
- **Backend**: Add `is_git_repository` and `detect_repositories` commands in Rust
- **Frontend**: Add `RepositoryDiscoverySection` component to `GitSettingsModal`
- **Store**: Add `remoteUrl` field to `RepositoryInfo` type

## Features
- Recursive scan up to 5 levels deep
- Continues scanning inside git repos to find nested repos (submodules, monorepo packages)
- Shows primary remote URL (prefers "origin", falls back to first remote)
- Skips common non-project directories (node_modules, .git, target, etc.)

Split from PR #91 for focused review.

## Test plan
- [ ] Open a multi-repo workspace (folder containing multiple git repos)
- [ ] Click the settings icon in the Git section of the sidebar
- [ ] Verify the new "Repository Discovery" section is visible
- [ ] Click "Scan for Repositories"
- [ ] Verify loading indicator appears
- [ ] Verify found repositories are listed with name, branch, and remote URL

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>