### PR TITLE
Add multi-repo workspace support to pre-launch UI

### DIFF
--- a/src/components/shared/MultiProjectView.tsx
+++ b/src/components/shared/MultiProjectView.tsx
@@ -24,6 +24,7 @@ export const MultiProjectView = forwardRef<MultiProjectViewHandle, MultiProjectV
   function MultiProjectView({ onSessionCountChange }, ref) {
   const tabs = useWorkspaceStore((s) => s.tabs);
   const setSessionsLaunched = useWorkspaceStore((s) => s.setSessionsLaunched);
+  const setSelectedRepo = useWorkspaceStore((s) => s.setSelectedRepo);
   const gridRefs = useRef<Map<string, TerminalGridHandle>>(new Map());
 
   // Expose methods to parent
@@ -66,6 +67,17 @@ export const MultiProjectView = forwardRef<MultiProjectViewHandle, MultiProjectV
     }
     return callbacks;
   }, [tabs, setSessionsLaunched]);
+
+  // Stable repo change callbacks per tab
+  const repoChangeCallbacks = useMemo(() => {
+    const callbacks = new Map<string, (path: string) => void>();
+    for (const tab of tabs) {
+      callbacks.set(tab.id, (path: string) => {
+        setSelectedRepo(tab.id, path);
+      });
+    }
+    return callbacks;
+  }, [tabs, setSelectedRepo]);
 
   // Stable ref setters per tab
   const gridRefSetters = useMemo(() => {
@@ -114,6 +126,10 @@ export const MultiProjectView = forwardRef<MultiProjectViewHandle, MultiProjectV
               ref={gridRefSetters.get(tab.id)}
               tabId={tab.id}
               projectPath={tab.projectPath}
+              repoPath={tab.selectedRepoPath ?? undefined}
+              repositories={tab.repositories}
+              workspaceType={tab.workspaceType}
+              onRepoChange={repoChangeCallbacks.get(tab.id)}
               preserveOnHide={true}
               onSessionCountChange={sessionCountChangeCallbacks.get(tab.id)}
             />

--- a/src/components/terminal/PreLaunchCard.tsx
+++ b/src/components/terminal/PreLaunchCard.tsx
@@ -5,12 +5,15 @@ import {
   ChevronRight,
   Code2,
   FolderGit2,
+  FolderOpen,
   GitBranch,
+  Loader2,
   Package,
   Play,
   Search,
   Server,
   Sparkles,
+  Star,
   Store,
   Terminal,
   X,
@@ -22,6 +25,7 @@ import type { BranchWithWorktreeStatus } from "@/lib/git";
 import type { McpServerConfig } from "@/lib/mcp";
 import type { PluginConfig, SkillConfig, SkillSource } from "@/lib/plugins";
 import type { AiMode } from "@/stores/useSessionStore";
+import type { RepositoryInfo, WorkspaceType } from "@/stores/useWorkspaceStore";
 
 /** Returns badge styling and text for a skill source. */
 function getSkillSourceLabel(source: SkillSource): { text: string; className: string } {
@@ -73,6 +77,16 @@ interface PreLaunchCardProps {
   branches: BranchWithWorktreeStatus[];
   isLoadingBranches: boolean;
   isGitRepo: boolean;
+  /** List of repositories for multi-repo workspaces. */
+  repositories?: RepositoryInfo[];
+  /** Workspace type - single-repo, multi-repo, or non-git. */
+  workspaceType?: WorkspaceType;
+  /** Currently selected repository path. */
+  selectedRepoPath?: string;
+  /** Callback to change the selected repository. */
+  onRepoChange?: (path: string) => void;
+  /** Function to fetch branches for any repository (for lazy loading). */
+  fetchBranchesForRepo?: (repoPath: string) => Promise<BranchWithWorktreeStatus[]>;
   mcpServers: McpServerConfig[];
   skills: SkillConfig[];
   plugins: PluginConfig[];
@@ -105,6 +119,11 @@ export function PreLaunchCard({
   branches,
   isLoadingBranches,
   isGitRepo,
+  repositories,
+  workspaceType,
+  selectedRepoPath,
+  onRepoChange,
+  fetchBranchesForRepo,
   mcpServers,
   skills,
   plugins,
@@ -128,6 +147,12 @@ export function PreLaunchCard({
   const [mcpSearchQuery, setMcpSearchQuery] = useState("");
   const [pluginsSearchQuery, setPluginsSearchQuery] = useState("");
   const [branchSearchQuery, setBranchSearchQuery] = useState("");
+
+  // Multi-repo state: track expanded repos and cached branches per repo
+  const [expandedRepos, setExpandedRepos] = useState<Set<string>>(new Set());
+  const [repoBranchesCache, setRepoBranchesCache] = useState<Map<string, BranchWithWorktreeStatus[]>>(new Map());
+  const [loadingRepos, setLoadingRepos] = useState<Set<string>>(new Set());
+
   const modeDropdownRef = useRef<HTMLDivElement>(null);
   const branchDropdownRef = useRef<HTMLDivElement>(null);
   const mcpDropdownRef = useRef<HTMLDivElement>(null);
@@ -221,6 +246,77 @@ export function PreLaunchCard({
   const localBranches = branches.filter((b) => !b.isRemote);
   const remoteBranches = branches.filter((b) => b.isRemote);
 
+  // Check if this is a multi-repo workspace
+  const isMultiRepo = workspaceType === "multi-repo" && repositories && repositories.length > 0;
+
+  // Get the display name for a repo path (folder name)
+  const getRepoDisplayName = (path: string): string => {
+    const repo = repositories?.find((r) => r.path === path);
+    return repo?.name ?? path.split("/").pop() ?? path;
+  };
+
+  // Toggle repo expansion and fetch branches if needed
+  const toggleRepoExpanded = async (repoPath: string) => {
+    const newExpanded = new Set(expandedRepos);
+
+    if (newExpanded.has(repoPath)) {
+      // Collapsing
+      newExpanded.delete(repoPath);
+      setExpandedRepos(newExpanded);
+    } else {
+      // Expanding - fetch branches if not cached
+      newExpanded.add(repoPath);
+      setExpandedRepos(newExpanded);
+
+      if (!repoBranchesCache.has(repoPath) && fetchBranchesForRepo) {
+        setLoadingRepos((prev) => new Set(prev).add(repoPath));
+        try {
+          const fetchedBranches = await fetchBranchesForRepo(repoPath);
+          setRepoBranchesCache((prev) => new Map(prev).set(repoPath, fetchedBranches));
+        } catch (err) {
+          console.error("Failed to fetch branches for repo:", err);
+        } finally {
+          setLoadingRepos((prev) => {
+            const next = new Set(prev);
+            next.delete(repoPath);
+            return next;
+          });
+        }
+      }
+    }
+  };
+
+  // Handle selecting a repo (use current branch)
+  const handleSelectRepo = (repoPath: string) => {
+    if (onRepoChange) {
+      onRepoChange(repoPath);
+    }
+    onBranchChange(null); // Use current branch
+    setBranchDropdownOpen(false);
+    setBranchSearchQuery("");
+  };
+
+  // Handle selecting a branch under a specific repo
+  const handleSelectRepoBranch = (repoPath: string, branchName: string | null) => {
+    if (onRepoChange && repoPath !== selectedRepoPath) {
+      onRepoChange(repoPath);
+    }
+    onBranchChange(branchName);
+    setBranchDropdownOpen(false);
+    setBranchSearchQuery("");
+  };
+
+  // Populate cache with current branches on mount/when branches change
+  useEffect(() => {
+    if (selectedRepoPath && branches.length > 0) {
+      setRepoBranchesCache((prev) => new Map(prev).set(selectedRepoPath, branches));
+    }
+  }, [selectedRepoPath, branches]);
+
+  // Get the selected repo info for display
+  const selectedRepo = repositories?.find((r) => r.path === selectedRepoPath);
+  const selectedRepoName = selectedRepo?.name ?? getRepoDisplayName(selectedRepoPath ?? "");
+
   return (
     <div className="content-dark terminal-cell flex h-full flex-col items-center justify-center bg-maestro-bg p-4">
       {/* Card content */}
@@ -284,12 +380,12 @@ export function PreLaunchCard({
           )}
         </div>
 
-        {/* Branch Selector */}
+        {/* Repository & Branch Selector */}
         <div className="relative" ref={branchDropdownRef}>
           <label className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-maestro-muted">
-            Git Branch
+            {isMultiRepo ? "Repository & Branch" : "Git Branch"}
           </label>
-          {!isGitRepo ? (
+          {!isGitRepo && !isMultiRepo ? (
             <div className="flex items-center gap-2 rounded border border-maestro-border bg-maestro-card/50 px-3 py-2 text-sm text-maestro-muted">
               <Terminal size={14} />
               <span>Not a Git repository</span>
@@ -303,8 +399,20 @@ export function PreLaunchCard({
                 className="flex w-full items-center justify-between gap-2 rounded border border-maestro-border bg-maestro-card px-3 py-2 text-left text-sm text-maestro-text transition-colors hover:border-maestro-accent/50 disabled:opacity-50"
               >
                 <div className="flex min-w-0 items-center gap-2">
-                  <GitBranch size={14} className="shrink-0 text-maestro-accent" />
-                  <span className="truncate">{displayBranch}</span>
+                  {isMultiRepo ? (
+                    <>
+                      <FolderOpen size={14} className="shrink-0 text-maestro-purple" />
+                      <span className="truncate">{selectedRepoName}</span>
+                      <span className="text-maestro-muted">/</span>
+                      <GitBranch size={12} className="shrink-0 text-maestro-accent" />
+                      <span className="truncate text-maestro-muted">{displayBranch}</span>
+                    </>
+                  ) : (
+                    <>
+                      <GitBranch size={14} className="shrink-0 text-maestro-accent" />
+                      <span className="truncate">{displayBranch}</span>
+                    </>
+                  )}
                   {selectedBranchInfo?.hasWorktree && (
                     <span title="Worktree exists">
                       <FolderGit2 size={12} className="shrink-0 text-maestro-orange" />
@@ -327,7 +435,7 @@ export function PreLaunchCard({
                       <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-maestro-muted" />
                       <input
                         type="text"
-                        placeholder="Search branches..."
+                        placeholder={isMultiRepo ? "Search repos and branches..." : "Search branches..."}
                         value={branchSearchQuery}
                         onChange={(e) => setBranchSearchQuery(e.target.value)}
                         className="w-full rounded border border-maestro-border bg-maestro-surface py-1.5 pl-7 pr-2 text-xs text-maestro-text placeholder:text-maestro-muted focus:border-maestro-accent focus:outline-none"
@@ -335,117 +443,257 @@ export function PreLaunchCard({
                       />
                     </div>
                   </div>
-                  {/* Branch list */}
-                  <div className="max-h-48 overflow-y-auto">
-                    {/* Current branch option - only show if not searching or if it matches */}
-                    {(!branchSearchQuery || "use current branch".includes(branchSearchQuery.toLowerCase())) && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onBranchChange(null);
-                          setBranchDropdownOpen(false);
-                          setBranchSearchQuery("");
-                        }}
-                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                          slot.branch === null
-                            ? "bg-maestro-accent/10 text-maestro-text"
-                            : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
-                        }`}
-                      >
-                        <GitBranch size={14} />
-                        <span>Use current branch</span>
-                      </button>
-                    )}
 
-                    {/* Local branches */}
-                    {localBranches.filter((b) =>
-                      b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
-                    ).length > 0 && (
-                      <>
-                        <div className="border-t border-maestro-border px-3 py-1 text-[9px] font-medium uppercase tracking-wide text-maestro-muted">
-                          Local
-                        </div>
-                        {localBranches
-                          .filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase()))
-                          .map((branch) => (
-                            <button
-                              key={branch.name}
-                              type="button"
-                              onClick={() => {
-                                onBranchChange(branch.name);
-                                setBranchDropdownOpen(false);
-                                setBranchSearchQuery("");
-                              }}
-                              className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                slot.branch === branch.name
-                                  ? "bg-maestro-accent/10 text-maestro-text"
-                                  : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
-                              }`}
-                            >
-                              <GitBranch size={14} />
-                              <span className="truncate">{branch.name}</span>
-                              {branch.hasWorktree && (
-                                <span title="Worktree exists">
-                                  <FolderGit2 size={12} className="shrink-0 text-maestro-orange" />
-                                </span>
-                              )}
-                              {branch.isCurrent && (
-                                <span className="shrink-0 rounded bg-maestro-green/20 px-1 text-[9px] text-maestro-green">
-                                  current
-                                </span>
-                              )}
-                            </button>
-                          ))}
-                      </>
-                    )}
+                  {/* Multi-repo view with expandable repos */}
+                  {isMultiRepo ? (
+                    <div className="max-h-64 overflow-y-auto">
+                      {repositories?.filter((repo) =>
+                        !branchSearchQuery ||
+                        repo.name.toLowerCase().includes(branchSearchQuery.toLowerCase()) ||
+                        repoBranchesCache.get(repo.path)?.some((b) =>
+                          b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
+                        )
+                      ).map((repo) => {
+                        const isSelected = repo.path === selectedRepoPath;
+                        const isExpanded = expandedRepos.has(repo.path);
+                        const isLoading = loadingRepos.has(repo.path);
+                        const repoBranches = repoBranchesCache.get(repo.path) ?? [];
+                        const repoLocalBranches = repoBranches.filter((b) => !b.isRemote);
+                        const currentRepoBranch = repoBranches.find((b) => b.isCurrent);
 
-                    {/* Remote branches */}
-                    {remoteBranches.filter((b) =>
-                      b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
-                    ).length > 0 && (
-                      <>
-                        <div className="border-t border-maestro-border px-3 py-1 text-[9px] font-medium uppercase tracking-wide text-maestro-muted">
-                          Remote
-                        </div>
-                        {remoteBranches
-                          .filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase()))
-                          .map((branch) => (
-                            <button
-                              key={branch.name}
-                              type="button"
-                              onClick={() => {
-                                onBranchChange(branch.name);
-                                setBranchDropdownOpen(false);
-                                setBranchSearchQuery("");
-                              }}
-                              className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                slot.branch === branch.name
-                                  ? "bg-maestro-accent/10 text-maestro-text"
-                                  : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
-                              }`}
-                            >
-                              <GitBranch size={14} className="text-maestro-muted/60" />
-                              <span className="truncate">{branch.name}</span>
-                              {branch.hasWorktree && (
-                                <span title="Worktree exists">
-                                  <FolderGit2 size={12} className="shrink-0 text-maestro-orange" />
-                                </span>
-                              )}
-                            </button>
-                          ))}
-                      </>
-                    )}
+                        // Filter branches by search query
+                        const filteredBranches = branchSearchQuery
+                          ? repoLocalBranches.filter((b) =>
+                              b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
+                            )
+                          : repoLocalBranches;
 
-                    {/* No results message */}
-                    {branchSearchQuery &&
-                      localBranches.filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())).length === 0 &&
-                      remoteBranches.filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())).length === 0 &&
-                      !"use current branch".includes(branchSearchQuery.toLowerCase()) && (
+                        return (
+                          <div key={repo.path} className={isSelected ? "bg-maestro-accent/5" : ""}>
+                            {/* Repo header row */}
+                            <div className="flex items-center gap-1 px-2 py-1.5 hover:bg-maestro-surface">
+                              {/* Expand/collapse button */}
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleRepoExpanded(repo.path);
+                                }}
+                                className="shrink-0 rounded p-0.5 hover:bg-maestro-border/40"
+                              >
+                                {isLoading ? (
+                                  <Loader2 size={12} className="animate-spin text-maestro-muted" />
+                                ) : isExpanded ? (
+                                  <ChevronDown size={12} className="text-maestro-muted" />
+                                ) : (
+                                  <ChevronRight size={12} className="text-maestro-muted" />
+                                )}
+                              </button>
+                              {/* Repo select button */}
+                              <button
+                                type="button"
+                                onClick={() => handleSelectRepo(repo.path)}
+                                className="flex flex-1 items-center gap-2 text-left text-sm"
+                              >
+                                <FolderOpen size={14} className="shrink-0 text-maestro-purple" />
+                                <span className={`flex-1 truncate ${isSelected ? "text-maestro-text font-medium" : "text-maestro-muted"}`}>
+                                  {repo.name}
+                                </span>
+                                {currentRepoBranch && (
+                                  <span className="text-[10px] text-maestro-muted">
+                                    {currentRepoBranch.name}
+                                  </span>
+                                )}
+                                {isSelected && (
+                                  <Check size={12} className="shrink-0 text-maestro-accent" />
+                                )}
+                              </button>
+                            </div>
+
+                            {/* Expanded branches */}
+                            {isExpanded && !isLoading && (
+                              <div className="ml-5 border-l border-maestro-border/40 pl-2">
+                                {/* Use current branch option */}
+                                <button
+                                  type="button"
+                                  onClick={() => handleSelectRepoBranch(repo.path, null)}
+                                  className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs transition-colors hover:bg-maestro-surface ${
+                                    isSelected && slot.branch === null
+                                      ? "bg-maestro-accent/10 text-maestro-text"
+                                      : "text-maestro-muted"
+                                  }`}
+                                >
+                                  <GitBranch size={12} />
+                                  <span>Use current branch</span>
+                                  {currentRepoBranch && (
+                                    <span className="text-[10px] text-maestro-muted/60">
+                                      ({currentRepoBranch.name})
+                                    </span>
+                                  )}
+                                </button>
+
+                                {/* Branch list */}
+                                {filteredBranches.map((branch) => {
+                                  const isBranchSelected = isSelected && slot.branch === branch.name;
+                                  return (
+                                    <button
+                                      key={branch.name}
+                                      type="button"
+                                      onClick={() => handleSelectRepoBranch(repo.path, branch.name)}
+                                      className={`flex w-full items-center gap-2 px-2 py-1 text-left text-xs transition-colors hover:bg-maestro-surface ${
+                                        isBranchSelected
+                                          ? "bg-maestro-accent/10 text-maestro-text"
+                                          : "text-maestro-muted"
+                                      }`}
+                                    >
+                                      <GitBranch size={11} />
+                                      <span className="flex-1 truncate">{branch.name}</span>
+                                      {branch.isCurrent && (
+                                        <Star size={10} className="shrink-0 text-maestro-green" fill="currentColor" />
+                                      )}
+                                      {branch.hasWorktree && (
+                                        <FolderGit2 size={10} className="shrink-0 text-maestro-orange" />
+                                      )}
+                                    </button>
+                                  );
+                                })}
+
+                                {filteredBranches.length === 0 && repoBranches.length > 0 && branchSearchQuery && (
+                                  <div className="px-2 py-1 text-[10px] text-maestro-muted">
+                                    No matching branches
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+
+                      {/* No repos match message */}
+                      {branchSearchQuery && repositories?.filter((repo) =>
+                        repo.name.toLowerCase().includes(branchSearchQuery.toLowerCase()) ||
+                        repoBranchesCache.get(repo.path)?.some((b) =>
+                          b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
+                        )
+                      ).length === 0 && (
                         <div className="px-3 py-2 text-center text-xs text-maestro-muted">
-                          No branches match "{branchSearchQuery}"
+                          No repos or branches match "{branchSearchQuery}"
                         </div>
                       )}
-                  </div>
+                    </div>
+                  ) : (
+                    /* Single-repo branch list (original behavior) */
+                    <div className="max-h-48 overflow-y-auto">
+                      {/* Current branch option - only show if not searching or if it matches */}
+                      {(!branchSearchQuery || "use current branch".includes(branchSearchQuery.toLowerCase())) && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onBranchChange(null);
+                            setBranchDropdownOpen(false);
+                            setBranchSearchQuery("");
+                          }}
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                            slot.branch === null
+                              ? "bg-maestro-accent/10 text-maestro-text"
+                              : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
+                          }`}
+                        >
+                          <GitBranch size={14} />
+                          <span>Use current branch</span>
+                        </button>
+                      )}
+
+                      {/* Local branches */}
+                      {localBranches.filter((b) =>
+                        b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
+                      ).length > 0 && (
+                        <>
+                          <div className="border-t border-maestro-border px-3 py-1 text-[9px] font-medium uppercase tracking-wide text-maestro-muted">
+                            Local
+                          </div>
+                          {localBranches
+                            .filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase()))
+                            .map((branch) => (
+                              <button
+                                key={branch.name}
+                                type="button"
+                                onClick={() => {
+                                  onBranchChange(branch.name);
+                                  setBranchDropdownOpen(false);
+                                  setBranchSearchQuery("");
+                                }}
+                                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                                  slot.branch === branch.name
+                                    ? "bg-maestro-accent/10 text-maestro-text"
+                                    : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
+                                }`}
+                              >
+                                <GitBranch size={14} />
+                                <span className="truncate">{branch.name}</span>
+                                {branch.hasWorktree && (
+                                  <span title="Worktree exists">
+                                    <FolderGit2 size={12} className="shrink-0 text-maestro-orange" />
+                                  </span>
+                                )}
+                                {branch.isCurrent && (
+                                  <span className="shrink-0 rounded bg-maestro-green/20 px-1 text-[9px] text-maestro-green">
+                                    current
+                                  </span>
+                                )}
+                              </button>
+                            ))}
+                        </>
+                      )}
+
+                      {/* Remote branches */}
+                      {remoteBranches.filter((b) =>
+                        b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())
+                      ).length > 0 && (
+                        <>
+                          <div className="border-t border-maestro-border px-3 py-1 text-[9px] font-medium uppercase tracking-wide text-maestro-muted">
+                            Remote
+                          </div>
+                          {remoteBranches
+                            .filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase()))
+                            .map((branch) => (
+                              <button
+                                key={branch.name}
+                                type="button"
+                                onClick={() => {
+                                  onBranchChange(branch.name);
+                                  setBranchDropdownOpen(false);
+                                  setBranchSearchQuery("");
+                                }}
+                                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                                  slot.branch === branch.name
+                                    ? "bg-maestro-accent/10 text-maestro-text"
+                                    : "text-maestro-muted hover:bg-maestro-surface hover:text-maestro-text"
+                                }`}
+                              >
+                                <GitBranch size={14} className="text-maestro-muted/60" />
+                                <span className="truncate">{branch.name}</span>
+                                {branch.hasWorktree && (
+                                  <span title="Worktree exists">
+                                    <FolderGit2 size={12} className="shrink-0 text-maestro-orange" />
+                                  </span>
+                                )}
+                              </button>
+                            ))}
+                        </>
+                      )}
+
+                      {/* No results message */}
+                      {branchSearchQuery &&
+                        localBranches.filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())).length === 0 &&
+                        remoteBranches.filter((b) => b.name.toLowerCase().includes(branchSearchQuery.toLowerCase())).length === 0 &&
+                        !"use current branch".includes(branchSearchQuery.toLowerCase()) && (
+                          <div className="px-3 py-2 text-center text-xs text-maestro-muted">
+                            No branches match "{branchSearchQuery}"
+                          </div>
+                        )}
+                    </div>
+                  )}
                 </div>
               )}
             </>

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -31,7 +31,7 @@ import { useMcpStore } from "@/stores/useMcpStore";
 import { usePluginStore } from "@/stores/usePluginStore";
 import { useSessionStore } from "@/stores/useSessionStore";
 import type { AiMode } from "@/stores/useSessionStore";
-import { useWorkspaceStore } from "@/stores/useWorkspaceStore";
+import { useWorkspaceStore, type RepositoryInfo, type WorkspaceType } from "@/stores/useWorkspaceStore";
 import { PreLaunchCard, type SessionSlot } from "./PreLaunchCard";
 import { TerminalView } from "./TerminalView";
 
@@ -126,6 +126,11 @@ export interface TerminalGridHandle {
 /**
  * @property projectPath - Working directory passed to `spawnShell`; when absent the backend
  *   uses its own default cwd.
+ * @property repoPath - Git repository path for branch/worktree operations. Defaults to projectPath.
+ *   For multi-repo workspaces, this is the selected repository path.
+ * @property repositories - List of all repositories in the workspace (for multi-repo workspaces).
+ * @property workspaceType - Type of workspace: "single-repo" | "multi-repo" | "non-git".
+ * @property onRepoChange - Callback to change the selected repository in multi-repo workspaces.
  * @property tabId - Workspace tab ID for session-project association.
  * @property preserveOnHide - If true, don't kill sessions when component unmounts (for project switching).
  * @property onSessionCountChange - Fires whenever session counts change,
@@ -133,6 +138,10 @@ export interface TerminalGridHandle {
  */
 interface TerminalGridProps {
   projectPath?: string;
+  repoPath?: string;
+  repositories?: RepositoryInfo[];
+  workspaceType?: WorkspaceType;
+  onRepoChange?: (path: string) => void;
   tabId?: string;
   preserveOnHide?: boolean;
   onSessionCountChange?: (slotCount: number, launchedCount: number) => void;
@@ -152,9 +161,12 @@ interface TerminalGridProps {
  *   a fresh slot so the user is never left with an empty grid.
  */
 export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(function TerminalGrid(
-  { projectPath, tabId, preserveOnHide = false, onSessionCountChange },
+  { projectPath, repoPath, repositories, workspaceType, onRepoChange, tabId, preserveOnHide = false, onSessionCountChange },
   ref,
 ) {
+  // Use repoPath for git operations, falling back to projectPath
+  const effectiveRepoPath = repoPath ?? projectPath;
+
   const addSessionToProject = useWorkspaceStore((s) => s.addSessionToProject);
   const removeSessionFromProject = useWorkspaceStore((s) => s.removeSessionFromProject);
 
@@ -235,15 +247,15 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
     onSessionCountChange?.(slots.length, launchedCount);
   }, [slots, onSessionCountChange]);
 
-  // Fetch branches and MCP servers when projectPath is available
+  // Fetch branches when effectiveRepoPath is available
   useEffect(() => {
-    if (!projectPath) {
+    if (!effectiveRepoPath) {
       setIsGitRepo(false);
       return;
     }
 
     setIsLoadingBranches(true);
-    getBranchesWithWorktreeStatus(projectPath)
+    getBranchesWithWorktreeStatus(effectiveRepoPath)
       .then((branchList) => {
         setBranches(branchList);
         setIsGitRepo(true);
@@ -254,6 +266,11 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
         setIsGitRepo(false);
         setIsLoadingBranches(false);
       });
+  }, [effectiveRepoPath]);
+
+  // Fetch MCP servers and plugins when projectPath is available
+  useEffect(() => {
+    if (!projectPath) return;
 
     // Fetch MCP servers
     fetchMcpServers(projectPath).catch(console.error);
@@ -333,7 +350,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
    * Called when slot config changes (plugins, skills, MCP servers).
    */
   const debouncedSaveBranchConfig = useCallback((slot: SessionSlot) => {
-    if (!projectPath || !slot.branch) return;
+    if (!effectiveRepoPath || !slot.branch) return;
 
     // Clear existing timer for this slot
     const existingTimer = branchConfigSaveTimers.current.get(slot.id);
@@ -343,7 +360,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
 
     // Set new timer
     const timer = setTimeout(() => {
-      saveBranchConfig(projectPath, slot.branch!, {
+      saveBranchConfig(effectiveRepoPath, slot.branch!, {
         enabled_plugins: slot.enabledPlugins,
         enabled_skills: slot.enabledSkills,
         enabled_mcp_servers: slot.enabledMcpServers,
@@ -354,7 +371,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
     }, 500);
 
     branchConfigSaveTimers.current.set(slot.id, timer);
-  }, [projectPath]);
+  }, [effectiveRepoPath]);
 
   // Save branch config when slot config changes (debounced)
   // Track previous slots to detect config changes
@@ -398,8 +415,8 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
 
     try {
       // Save branch config before launching (ensures it's persisted)
-      if (projectPath && slot.branch) {
-        await saveBranchConfig(projectPath, slot.branch, {
+      if (effectiveRepoPath && slot.branch) {
+        await saveBranchConfig(effectiveRepoPath, slot.branch, {
           enabled_plugins: slot.enabledPlugins,
           enabled_skills: slot.enabledSkills,
           enabled_mcp_servers: slot.enabledMcpServers,
@@ -411,12 +428,13 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
 
       // Determine the working directory
       // If a branch is selected, prepare a worktree first
-      let workingDirectory = projectPath;
+      // For multi-repo workspaces, use effectiveRepoPath for git operations
+      let workingDirectory = effectiveRepoPath ?? projectPath;
       let worktreePath: string | null = null;
       let worktreeWarning: string | null = null;
 
-      if (projectPath && slot.branch) {
-        const result = await prepareSessionWorktree(projectPath, slot.branch);
+      if (effectiveRepoPath && slot.branch) {
+        const result = await prepareSessionWorktree(effectiveRepoPath, slot.branch);
         workingDirectory = result.working_directory;
         worktreePath = result.worktree_path;
         worktreeWarning = result.warning;
@@ -555,7 +573,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
       console.error("Failed to spawn shell:", err);
       setError("Failed to start terminal session");
     }
-  }, [projectPath, tabId, addSessionToProject]);
+  }, [projectPath, effectiveRepoPath, tabId, addSessionToProject]);
 
   /**
    * Launches a single slot by spawning a shell with the configured settings.
@@ -616,10 +634,11 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
     }
 
     // Clean up worktree if one was created (fire-and-forget)
-    if (projectPath && worktreePath) {
-      cleanupSessionWorktree(projectPath, worktreePath).catch(console.error);
+    // Use effectiveRepoPath for worktree cleanup since worktrees are git-repo specific
+    if (effectiveRepoPath && worktreePath) {
+      cleanupSessionWorktree(effectiveRepoPath, worktreePath).catch(console.error);
     }
-  }, [tabId, projectPath, removeSessionFromProject]);
+  }, [tabId, effectiveRepoPath, projectPath, removeSessionFromProject]);
 
   /**
    * Removes a pre-launch slot (before it's launched).
@@ -651,10 +670,10 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
       )
     );
 
-    // If a branch is selected and we have a project path, try to load saved config
-    if (branch && projectPath) {
+    // If a branch is selected and we have a repo path, try to load saved config
+    if (branch && effectiveRepoPath) {
       try {
-        const savedConfig = await loadBranchConfig(projectPath, branch);
+        const savedConfig = await loadBranchConfig(effectiveRepoPath, branch);
         if (savedConfig) {
           // Apply saved config to the slot
           setSlots((prev) =>
@@ -674,7 +693,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
         // Non-fatal - continue with current slot config
       }
     }
-  }, [projectPath]);
+  }, [effectiveRepoPath]);
 
   /**
    * Toggles an MCP server for a slot.
@@ -872,6 +891,11 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
             branches={branches}
             isLoadingBranches={isLoadingBranches}
             isGitRepo={isGitRepo}
+            repositories={repositories}
+            workspaceType={workspaceType}
+            selectedRepoPath={effectiveRepoPath}
+            onRepoChange={onRepoChange}
+            fetchBranchesForRepo={getBranchesWithWorktreeStatus}
             mcpServers={mcpServers}
             skills={skills}
             plugins={plugins}


### PR DESCRIPTION
## Summary
- Adds support for selecting between multiple repositories in a workspace
- PreLaunchCard now shows expandable repo list with lazy branch loading
- Search across repos and branches with visual hierarchy for repo/branch selection
- TerminalGrid passes multi-repo context to PreLaunchCard

## Changes
- **PreLaunchCard**: Expandable repo list with lazy branch loading, search across repos and branches
- **TerminalGrid**: New `repoPath` prop for git operations separate from `projectPath`
- **MultiProjectView**: Wires up repo change callbacks to workspace store

## Dependencies
This PR works best when combined with:
- PR #115 (Repository Discovery) - provides the `detect_repositories` scan

Split from PR #91 for focused review.

## Test plan
- [ ] Open a workspace with multiple git repositories
- [ ] Verify repo dropdown appears in PreLaunchCard
- [ ] Expand a repo to see its branches
- [ ] Search for a branch across all repos
- [ ] Select a branch from a different repo
- [ ] Verify the session launches with the correct repo/branch

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>