### PR TITLE
fix(docs): Use ruby/setup-ruby for Jekyll build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/jekyll-build-pages@v1
+
+      - uses: ruby/setup-ruby@v1
         with:
-          source: ./website
-          destination: ./_site
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: website
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build --baseurl "/maestro"
+        working-directory: website
+        env:
+          JEKYLL_ENV: production
+
+      - uses: actions/configure-pages@v5
+
       - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/_site
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary

- Fixes the docs deployment workflow — `jekyll-build-pages` uses the `github-pages` gem which doesn't include `just-the-docs`
- Switches to `ruby/setup-ruby` with `bundler-cache: true` to install gems from `website/Gemfile` directly
- Builds Jekyll manually with `bundle exec jekyll build`

## Test plan

- [ ] Verify the "Deploy Docs" workflow passes after merge
- [ ] Confirm site loads at `https://its-maestro-baby.github.io/maestro/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)