### PR TITLE
fix(terminal): add Cmd+Arrow line jump and Cmd+Delete on macOS

### DIFF
--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -316,6 +316,24 @@ export const TerminalView = memo(function TerminalView({
           return false; // Don't send to PTY
         }
 
+        // Cmd+Left/Right (Mac): jump to beginning/end of line
+        // Cmd+Delete (Mac): delete from cursor to beginning of line
+        // WebView intercepts Cmd+key by default, so we manually send the escape sequences
+        if (event.metaKey && event.type === "keydown") {
+          if (event.key === "ArrowLeft") {
+            writeStdin(sessionId, "\x01").catch(console.error); // Ctrl+A: beginning of line
+            return false;
+          }
+          if (event.key === "ArrowRight") {
+            writeStdin(sessionId, "\x05").catch(console.error); // Ctrl+E: end of line
+            return false;
+          }
+          if (event.key === "Backspace") {
+            writeStdin(sessionId, "\x15").catch(console.error); // Ctrl+U: delete to beginning of line
+            return false;
+          }
+        }
+
         return true; // Let xterm handle all other keys
       });
 


### PR DESCRIPTION
## Summary
- Add `Cmd+Left` / `Cmd+Right` support to jump to beginning/end of line in the terminal
- Add `Cmd+Delete` (Backspace) support to delete from cursor to beginning of line
- These key combinations are intercepted by the WebView by default, so we manually send the corresponding readline escape sequences (`Ctrl+A`, `Ctrl+E`, `Ctrl+U`)

## Problem
On macOS, `Cmd+Arrow` and `Cmd+Delete` are standard shortcuts for line-level navigation and editing in terminals. However, in xterm.js running inside a Tauri WebView, the `Cmd` key combinations are intercepted by the WebView before reaching xterm.js, making these shortcuts non-functional.

`Option+Arrow` (word jump) already works because xterm.js handles Alt/Meta key combinations natively.

## Solution
Added handling in `attachCustomKeyEventHandler` to intercept these `Cmd` key combinations and write the equivalent readline escape sequences directly to the PTY:
- `Cmd+Left` → `\x01` (Ctrl+A: beginning of line)
- `Cmd+Right` → `\x05` (Ctrl+E: end of line)
- `Cmd+Backspace` → `\x15` (Ctrl+U: delete to beginning of line)

## Test plan
- [ ] Verify `Cmd+Left` moves cursor to beginning of line
- [ ] Verify `Cmd+Right` moves cursor to end of line
- [ ] Verify `Cmd+Delete` deletes text from cursor to beginning of line
- [ ] Verify `Option+Arrow` word jump still works
- [ ] Verify `Cmd+C` copy still works when text is selected
- [ ] Verify `Cmd+C` sends SIGINT when no text is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)