### PR TITLE
feat(keyboard): add Cmd+T shortcut to create new session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useSessionStore } from "@/stores/useSessionStore";
 import { useWorkspaceStore } from "@/stores/useWorkspaceStore";
 import { useGitStore } from "./stores/useGitStore";
 import { useTerminalSettingsStore } from "./stores/useTerminalSettingsStore";
+import { useAppKeyboard } from "./hooks/useAppKeyboard";
 import { useSwipeNavigation } from "./hooks/useSwipeNavigation";
 import { GitGraphPanel } from "./components/git/GitGraphPanel";
 import { BottomBar } from "./components/shared/BottomBar";
@@ -164,6 +165,16 @@ function App() {
   const activeTabCounts = activeTab ? sessionCounts.get(activeTab.id) : undefined;
   const activeTabSlotCount = activeTabCounts?.slotCount ?? 0;
   const activeTabLaunchedCount = activeTabCounts?.launchedCount ?? 0;
+
+  // Cmd/Ctrl+T: add a new session slot in grid view
+  const handleAddSessionShortcut = useCallback(() => {
+    multiProjectRef.current?.addSessionToActiveProject();
+  }, []);
+
+  useAppKeyboard({
+    onAddSession: handleAddSessionShortcut,
+    canAddSession: activeTabSessionsLaunched,
+  });
 
   // Handler to enter grid view for the active project
   const handleEnterGridView = () => {

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -378,6 +378,12 @@ export const TerminalView = memo(function TerminalView({
           return false; // Don't send to PTY
         }
 
+        // Cmd/Ctrl+T: add new session — block xterm so 't' isn't sent to PTY.
+        // The DOM event still bubbles to window where useAppKeyboard handles it.
+        if (event.key === "t" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.type === "keydown") {
+          return false;
+        }
+
         // Cmd+Left/Right (Mac): jump to beginning/end of line
         // Cmd+Delete (Mac): delete from cursor to beginning of line
         // WebView intercepts Cmd+key by default, so we manually send the escape sequences

--- a/src/hooks/useAppKeyboard.ts
+++ b/src/hooks/useAppKeyboard.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+interface UseAppKeyboardOptions {
+  /** Callback to add a new session */
+  onAddSession: () => void;
+  /** Whether adding a session is currently allowed (e.g. in grid view) */
+  canAddSession: boolean;
+}
+
+/**
+ * Detect whether the current platform uses Cmd (Mac) or Ctrl (Windows/Linux) as the modifier key.
+ */
+function isMac(): boolean {
+  return navigator.platform.toLowerCase().includes("mac");
+}
+
+/**
+ * App-level keyboard shortcut handler.
+ *
+ * Shortcuts:
+ * - Cmd/Ctrl+T: Add a new session slot (when in grid view)
+ */
+export function useAppKeyboard({ onAddSession, canAddSession }: UseAppKeyboardOptions): void {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const modifierKey = isMac() ? event.metaKey : event.ctrlKey;
+      if (!modifierKey) return;
+
+      // Don't interfere with other modifier combinations
+      if (event.altKey || event.shiftKey) return;
+
+      if (event.key === "t") {
+        // Always prevent default to block WebView's new-tab behavior
+        event.preventDefault();
+        if (canAddSession) {
+          onAddSession();
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onAddSession, canAddSession]);
+}


### PR DESCRIPTION
## Summary
- Add `Cmd/Ctrl+T` keyboard shortcut to create a new session slot in grid view
- Block xterm.js from capturing `Cmd/Ctrl+T` so the event bubbles to the app-level handler
- New `useAppKeyboard` hook for app-wide keyboard shortcuts

## Details
When sessions are launched and the user is in grid view, pressing `Cmd+T` (Mac) or `Ctrl+T` (Windows/Linux) adds a new pre-launch session slot — similar to how terminal emulators add new tabs.

### Files changed
- `src/hooks/useAppKeyboard.ts` — New hook handling app-level keyboard shortcuts
- `src/App.tsx` — Wire up the `useAppKeyboard` hook with `addSessionToActiveProject`
- `src/components/terminal/TerminalView.tsx` — Block `Cmd/Ctrl+T` in xterm.js custom key handler so the keystroke isn't consumed by the terminal

## Test plan
- [ ] In grid view with active sessions, press `Cmd+T` (Mac) / `Ctrl+T` (Win/Linux) → new pre-launch card appears
- [ ] In grid view without sessions (landing page), `Cmd+T` does nothing (no crash)
- [ ] While focused on a terminal, `Cmd+T` does NOT send 't' to the PTY
- [ ] Other `Cmd+key` shortcuts (copy, paste, etc.) still work normally
- [ ] On Windows/Linux, `Ctrl+T` works instead of `Cmd+T`

🤖 Generated with [Claude Code](https://claude.com/claude-code)