### PR TITLE
fix(terminal): resolve CJK input garbling and insertion display corruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tauri-apps/plugin-store": "^2.4.2",
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
@@ -1854,6 +1855,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/plugin-store": "^2.4.2",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",

--- a/src-tauri/src/core/process_manager.rs
+++ b/src-tauri/src/core/process_manager.rs
@@ -220,6 +220,16 @@ impl ProcessManager {
         #[cfg(unix)]
         cmd.env("TERM", "xterm-256color");
 
+        // Ensure UTF-8 locale for proper multi-byte character handling.
+        // macOS Terminal.app/iTerm2 set LANG before launching shells, but Tauri
+        // apps launched from Finder/Dock/Spotlight don't inherit that setting.
+        // Without a UTF-8 locale, zsh/bash treat CJK characters as raw bytes,
+        // causing garbled display and incorrect cursor positioning.
+        #[cfg(unix)]
+        if std::env::var("LANG").unwrap_or_default().is_empty() {
+            cmd.env("LANG", "en_US.UTF-8");
+        }
+
         // Inject MAESTRO_SESSION_ID automatically (used by MCP status server)
         cmd.env("MAESTRO_SESSION_ID", id.to_string());
 


### PR DESCRIPTION
## Summary

- **Set UTF-8 locale for PTY shells** — Tauri apps launched from Finder/Dock don't inherit `LANG`, causing zsh to fall back to `LC_CTYPE=C` and treat CJK characters as raw bytes, producing garbled output like `<0087><00ad>`
- **Intercept `compositionend` to bypass xterm.js textarea accumulation bug** — On WebKit/WKWebView, the hidden textarea accumulates text across compositions, causing `CompositionHelper` to extract the wrong substring (e.g. sending "測試" instead of "這是")
- **Load `@xterm/addon-unicode11`** — Provides correct CJK fullwidth character width tables so xterm.js rendering aligns with shell cursor positioning

## Test plan

- [ ] Use Zhuyin (Bopomofo) IME to type Chinese characters in the terminal — verify no garbled bytes appear
- [ ] Type "測試文字", move cursor to the beginning, type "這是" — verify result is "這是測試文字"
- [ ] Run `locale` in terminal — verify `LANG` is set to `en_US.UTF-8` (when not inherited from parent)
- [ ] Verify normal ASCII input still works correctly
- [ ] Verify Shift+Enter, Cmd+C copy, Cmd+Arrow shortcuts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)