### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "maestro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "maestro-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",

--- a/maestro-mcp-server/Cargo.toml
+++ b/maestro-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "MCP server for Claude Maestro status reporting"
 authors = ["lliWcWill"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maestro-linux",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maestro-linux",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maestro-linux",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "engines": {
     "node": ">=18.0.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro"
-version = "0.1.0"
+version = "0.2.0"
 description = "Maestro — Multi-session AI orchestrator"
 authors = ["lliWcWill"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Maestro",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.maestro.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Bump version from 0.1.0 → 0.2.0 across all manifest files to match the v0.2.0 release scope.

### Files updated
- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `maestro-mcp-server/Cargo.toml`
- `package.json`
- `package-lock.json`
- `Cargo.lock`

## Context

PR #146 "Release v0.2.0" was merged on Feb 10, and PR #147 landed a massive set of features, but all version strings still read `0.1.0`. This aligns the manifests with the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)