### PR TITLE
feat: add Cmd-K to clear terminal

### DIFF
--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -420,6 +420,12 @@ export const TerminalView = memo(function TerminalView({
           return false;
         }
 
+        // Cmd+K (Mac) or Ctrl+K (Linux/Windows): clear terminal scrollback + viewport
+        if (event.key === "k" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.type === "keydown") {
+          term?.clear();
+          return false;
+        }
+
         // Cmd+Left/Right (Mac): jump to beginning/end of line
         // Cmd+Delete (Mac): delete from cursor to beginning of line
         // WebView intercepts Cmd+key by default, so we manually send the escape sequences


### PR DESCRIPTION
## Summary
- Adds **Cmd-K** (macOS) / **Ctrl-K** (Linux/Windows) keyboard shortcut to clear the terminal viewport and scrollback buffer, matching iTerm2 and VS Code behavior
- Uses xterm.js built-in `term.clear()` method
- Implemented in the existing `attachCustomKeyEventHandler` alongside other Cmd shortcuts

## Test plan
- [ ] On macOS, press Cmd-K in a terminal session and verify scrollback + viewport are cleared
- [ ] On Linux/Windows, press Ctrl-K and verify the same behavior
- [ ] Verify Cmd-K does not send 'k' to the PTY
- [ ] Verify other Cmd shortcuts (Cmd-T, Cmd-C, Cmd-Left/Right) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)