### PR TITLE
fix(macos): keep traffic light padding when window is maximized

### DIFF
--- a/src/hooks/useMacTitleBarPadding.ts
+++ b/src/hooks/useMacTitleBarPadding.ts
@@ -12,8 +12,8 @@ export const MAC_TITLE_BAR_INSET_PX = 74;
 /**
  * On macOS with native traffic lights: returns true when the title bar should
  * reserve left padding for the traffic lights (i.e. when they are visible).
- * When the window is maximized or fullscreen, traffic lights are hidden, so we
- * return false and content can use the full left edge.
+ * Traffic lights remain visible when maximized/snapped but are hidden in native
+ * fullscreen, so we only remove padding in fullscreen mode.
  */
 export function useMacTitleBarPadding(): boolean {
   const appWindow = useMemo(() => getCurrentWindow(), []);
@@ -25,8 +25,8 @@ export function useMacTitleBarPadding(): boolean {
     let unlistenResized: (() => void) | undefined;
 
     const updateVisibility = () => {
-      Promise.all([appWindow.isMaximized(), appWindow.isFullscreen()])
-        .then(([maximized, fullscreen]) => setTrafficLightsVisible(!maximized && !fullscreen))
+      appWindow.isFullscreen()
+        .then((fullscreen) => setTrafficLightsVisible(!fullscreen))
         .catch(() => setTrafficLightsVisible(true));
     };
 


### PR DESCRIPTION
Before
<img width="338" height="120" alt="Menubar_and_Tauri_App_and_fix_macos___keep_traffic_light_padding_when_window_is_maximized_by_mike-lead_·_Pull_Request__164_·_its-maestro-baby_maestro" src="https://github.com/user-attachments/assets/4a382a86-b026-43b1-814b-3177f79fe3a9" />

After
<img width="350" height="139" alt="Menubar_and_Tauri_App_and_architectural-review-2026-02-11_md_—_main" src="https://github.com/user-attachments/assets/45713d41-aafb-4612-96e6-a1b3e60b71e8" />


## Summary
- Removed the `isMaximized()` check from `useMacTitleBarPadding` so the 74px left padding is preserved when the window is maximized/snapped
- Traffic lights only disappear in native fullscreen (green button / Ctrl+Cmd+F), not when maximized — the previous logic incorrectly removed padding in both cases, causing overlap with the sidebar toggle and first tab

## Test plan
- [ ] Normal windowed mode: 74px left padding present, no overlap with traffic lights
- [ ] Snap/maximize (drag window to top): 74px left padding still present, no overlap
- [ ] True fullscreen (green button): padding removed (traffic lights hidden by OS)
- [ ] Resize back from fullscreen: padding returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)