### PR TITLE
feat: per-project worktree base path configuration

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,6 +185,7 @@ pub fn run() {
             // Worktree commands
             commands::worktree::prepare_session_worktree,
             commands::worktree::cleanup_session_worktree,
+            commands::worktree::get_default_worktree_base_dir,
             // MCP commands
             commands::mcp::get_project_mcp_servers,
             commands::mcp::refresh_project_mcp_servers,

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -173,6 +173,9 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
 
   const addSessionToProject = useWorkspaceStore((s) => s.addSessionToProject);
   const removeSessionFromProject = useWorkspaceStore((s) => s.removeSessionFromProject);
+  const worktreeBasePath = useWorkspaceStore((s) =>
+    tabId ? s.tabs.find((t) => t.id === tabId)?.worktreeBasePath ?? null : null
+  );
 
   // MCP store - use stable empty array reference to avoid infinite re-render loops
   const mcpServers = useMcpStore((s) =>
@@ -465,7 +468,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
       let worktreeWarning: string | null = null;
 
       if (effectiveRepoPath && slot.branch) {
-        const result = await prepareSessionWorktree(effectiveRepoPath, slot.branch);
+        const result = await prepareSessionWorktree(effectiveRepoPath, slot.branch, worktreeBasePath);
         workingDirectory = result.working_directory;
         worktreePath = result.worktree_path;
         worktreeWarning = result.warning;

--- a/src/lib/worktreeManager.ts
+++ b/src/lib/worktreeManager.ts
@@ -199,12 +199,14 @@ export async function getWorktreeForBranch(
  */
 export async function prepareSessionWorktree(
   projectPath: string,
-  branch: string | null
+  branch: string | null,
+  worktreeBasePath?: string | null
 ): Promise<WorktreePreparationResult> {
   try {
     const result = await invoke<WorktreePreparationResult>("prepare_session_worktree", {
       projectPath,
       branch,
+      worktreeBasePath: worktreeBasePath ?? null,
     });
 
     if (result.warning) {


### PR DESCRIPTION

<img width="328" height="297" alt="Menubar_and_Tauri_App_and_feat__per-project_worktree_base_path_configuration_by_mike-lead_·_Pull_Request__165_·_its-maestro-baby_maestro" src="https://github.com/user-attachments/assets/5b42d2d3-13c0-4c5f-bb83-3f00713f6d9c" />

<img width="539" height="262" alt="Tauri_App" src="https://github.com/user-attachments/assets/53520abb-4e66-416c-9ac9-bc4c10d208c0" />

the default of `~/Library/Application Support/com.maestro.maestro/worktrees/` on macOS caused issues with the space in the path so I made it customizable

## Summary

- Adds a configurable worktree base path per project, so users can choose where worktrees are stored instead of always using the default XDG data directory
- Displays the current worktree base path in the sidebar (shortened with tooltip for full path)
- Adds a "Worktree Base Path" section to the Git Settings modal with inline edit, folder picker, and reset-to-default

## Changes

**Backend (Rust):**
- `worktree_manager.rs`: Added `_with_base` method variants that accept an optional base path override, existing methods delegate with `None`
- `commands/worktree.rs`: Added `worktree_base_path` param to `prepare_session_worktree`, new `get_default_worktree_base_dir` command
- `lib.rs`: Registered the new command

**Frontend (TypeScript/React):**
- `useWorkspaceStore.ts`: Added `worktreeBasePath` field to `WorkspaceTab`, `setWorktreeBasePath` action, store version bump v3→v4 with migration
- `worktreeManager.ts`: Passes `worktreeBasePath` through to backend invoke
- `TerminalGrid.tsx`: Reads active tab's `worktreeBasePath` and passes it to `prepareSessionWorktree`
- `Sidebar.tsx`: Shows worktree base path below remotes with shortened display + tooltip
- `GitSettingsModal.tsx`: New `WorktreeSection` with edit, folder picker (`@tauri-apps/plugin-dialog`), and reset to default

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `npx tsc --noEmit` — no type errors
- [x] `cargo test -p maestro` — all 95 tests pass (existing tests unaffected)
- [ ] Manual: sidebar shows default worktree path below remotes
- [ ] Manual: Git Settings modal has new "Worktree Base Path" section
- [ ] Manual: edit path via text input or folder picker, save, verify sidebar updates
- [ ] Manual: start session with branch → worktree created under custom path
- [ ] Manual: reset to default → reverts to XDG path
- [ ] Manual: custom path persists across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)