### PR TITLE
feat(git): add push/pull/fetch commands and refactor status server

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -290,6 +290,51 @@ pub async fn detect_repositories(path: String) -> Result<Vec<RepositoryInfo>, Gi
     Ok(repos)
 }
 
+/// Pushes commits to a remote.
+#[tauri::command]
+pub async fn git_push(
+    repo_path: String,
+    remote: String,
+    branch: Option<String>,
+    set_upstream: Option<bool>,
+    force_with_lease: Option<bool>,
+) -> Result<String, GitError> {
+    validate_repo_path(&repo_path)?;
+    let git = Git::new(&repo_path);
+    git.push(
+        &remote,
+        branch.as_deref(),
+        set_upstream.unwrap_or(false),
+        force_with_lease.unwrap_or(false),
+    )
+    .await
+}
+
+/// Pulls changes from a remote.
+#[tauri::command]
+pub async fn git_pull(
+    repo_path: String,
+    remote: String,
+    branch: Option<String>,
+    ff_only: Option<bool>,
+) -> Result<String, GitError> {
+    validate_repo_path(&repo_path)?;
+    let git = Git::new(&repo_path);
+    git.pull(&remote, branch.as_deref(), ff_only.unwrap_or(true))
+        .await
+}
+
+/// Fetches refs and objects from a remote (or all if not specified).
+#[tauri::command]
+pub async fn git_fetch(
+    repo_path: String,
+    remote: Option<String>,
+) -> Result<(), GitError> {
+    validate_repo_path(&repo_path)?;
+    let git = Git::new(&repo_path);
+    git.fetch(remote.as_deref()).await
+}
+
 /// Internal recursive helper for detect_repositories.
 /// Uses Box::pin for async recursion.
 fn detect_repos_recursive<'a>(

--- a/src-tauri/src/core/api_types.rs
+++ b/src-tauri/src/core/api_types.rs
@@ -1,0 +1,93 @@
+//! Shared request/response types for the Maestro REST API.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// POST /api/v1/sessions — create a new Claude Code session.
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    pub project_path: String,
+    pub branch: Option<String>,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    pub initial_prompt: Option<String>,
+    #[serde(default)]
+    pub auto_push: bool,
+    #[serde(default)]
+    pub context: HashMap<String, serde_json::Value>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+fn default_mode() -> String {
+    "claude".to_string()
+}
+
+/// Response from session creation.
+#[derive(Debug, Serialize)]
+pub struct CreateSessionResponse {
+    pub session_id: u32,
+    pub status: String,
+    pub worktree_path: Option<String>,
+    pub working_directory: String,
+}
+
+/// GET /api/v1/sessions/:id — session detail.
+#[derive(Debug, Serialize)]
+pub struct SessionDetail {
+    pub id: u32,
+    pub status: String,
+    pub mode: String,
+    pub branch: Option<String>,
+    pub worktree_path: Option<String>,
+    pub project_path: String,
+}
+
+/// POST /api/v1/sessions/:id/input — write to session stdin.
+#[derive(Debug, Deserialize)]
+pub struct SessionInputRequest {
+    pub text: String,
+}
+
+/// POST /api/v1/apps — create a new app.
+#[derive(Debug, Deserialize)]
+pub struct CreateAppRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub template: Option<String>,
+}
+
+/// Response from app creation.
+#[derive(Debug, Serialize)]
+pub struct CreateAppResponse {
+    pub app_id: String,
+    pub path: String,
+}
+
+/// POST /api/v1/apps/:id/generate — start generation session.
+#[derive(Debug, Deserialize)]
+pub struct GenerateAppRequest {
+    pub prompt: String,
+    #[serde(default)]
+    pub auto_push: bool,
+}
+
+/// POST /api/v1/apps/:id/run — start run session.
+#[derive(Debug, Deserialize)]
+pub struct RunAppRequest {
+    pub command: Option<String>,
+}
+
+/// GET /api/v1/health — health check response.
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub instance_id: String,
+    pub port: u16,
+    pub version: String,
+}
+
+/// Generic error response for the API.
+#[derive(Debug, Serialize)]
+pub struct ApiError {
+    pub error: String,
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod api_types;
 pub mod error;
 pub mod font_detector;
 pub mod marketplace_error;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -639,6 +639,67 @@ impl Git {
 
         Ok(git_dir_canon != common_dir_canon)
     }
+
+    /// Pushes commits to a remote.
+    ///
+    /// If `branch` is None, pushes the current branch.
+    /// `set_upstream` adds `-u` to track the remote branch.
+    /// `force_with_lease` uses `--force-with-lease` (never bare `--force`).
+    pub async fn push(
+        &self,
+        remote: &str,
+        branch: Option<&str>,
+        set_upstream: bool,
+        force_with_lease: bool,
+    ) -> Result<String, GitError> {
+        let mut args = vec!["push"];
+        if set_upstream {
+            args.push("-u");
+        }
+        if force_with_lease {
+            args.push("--force-with-lease");
+        }
+        args.push(remote);
+        if let Some(b) = branch {
+            args.push(b);
+        }
+        let output = self.run(&args).await?;
+        Ok(output.trimmed().to_string())
+    }
+
+    /// Pulls changes from a remote.
+    ///
+    /// If `branch` is None, pulls the current branch's tracking remote.
+    /// `ff_only` uses `--ff-only` to prevent merge commits.
+    pub async fn pull(
+        &self,
+        remote: &str,
+        branch: Option<&str>,
+        ff_only: bool,
+    ) -> Result<String, GitError> {
+        let mut args = vec!["pull"];
+        if ff_only {
+            args.push("--ff-only");
+        }
+        args.push(remote);
+        if let Some(b) = branch {
+            args.push(b);
+        }
+        let output = self.run(&args).await?;
+        Ok(output.trimmed().to_string())
+    }
+
+    /// Fetches refs and objects from a remote (or all remotes if None).
+    pub async fn fetch(&self, remote: Option<&str>) -> Result<(), GitError> {
+        let mut args = vec!["fetch"];
+        if let Some(r) = remote {
+            args.push(r);
+        } else {
+            args.push("--all");
+        }
+        self.run(&args).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/stores/useGitStore.ts
+++ b/src/stores/useGitStore.ts
@@ -107,6 +107,9 @@ interface GitState {
   setDefaultBranch: (repoPath: string, branch: string, global?: boolean) => Promise<void>;
   getCommitFiles: (repoPath: string, commitHash: string) => Promise<FileChange[]>;
   getRefsForCommit: (repoPath: string, commitHash: string) => Promise<string[]>;
+  push: (repoPath: string, remote?: string, branch?: string, setUpstream?: boolean, forceWithLease?: boolean) => Promise<string>;
+  pull: (repoPath: string, remote?: string, branch?: string, ffOnly?: boolean) => Promise<string>;
+  fetch: (repoPath: string, remote?: string) => Promise<void>;
   reset: () => void;
 }
 
@@ -369,6 +372,55 @@ export const useGitStore = create<GitState>()((set, get) => ({
     } catch (err) {
       console.error("Failed to get refs for commit:", err);
       return [];
+    }
+  },
+
+  push: async (
+    repoPath: string,
+    remote = "origin",
+    branch?: string,
+    setUpstream = false,
+    forceWithLease = false,
+  ): Promise<string> => {
+    try {
+      return await invoke<string>("git_push", {
+        repoPath,
+        remote,
+        branch: branch ?? null,
+        setUpstream,
+        forceWithLease,
+      });
+    } catch (err) {
+      console.error("Failed to push:", err);
+      throw err;
+    }
+  },
+
+  pull: async (
+    repoPath: string,
+    remote = "origin",
+    branch?: string,
+    ffOnly = true,
+  ): Promise<string> => {
+    try {
+      return await invoke<string>("git_pull", {
+        repoPath,
+        remote,
+        branch: branch ?? null,
+        ffOnly,
+      });
+    } catch (err) {
+      console.error("Failed to pull:", err);
+      throw err;
+    }
+  },
+
+  fetch: async (repoPath: string, remote?: string): Promise<void> => {
+    try {
+      await invoke("git_fetch", { repoPath, remote: remote ?? null });
+    } catch (err) {
+      console.error("Failed to fetch:", err);
+      throw err;
     }
   },
 


### PR DESCRIPTION
## Summary
- Add `git_push`, `git_pull`, and `git_fetch` Tauri IPC commands with corresponding git runner ops
- Refactor status server with expanded functionality
- Add `api_types` module and `useGitStore` frontend store

## Test plan
- [ ] Verify push/pull/fetch commands work via Tauri IPC
- [ ] Test status server endpoints still respond correctly
- [ ] Confirm git store updates reactively in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)