### PR TITLE
feat(terminal): drag & drop files from Finder to paste paths

### DIFF
--- a/src/components/terminal/SplitPaneView.tsx
+++ b/src/components/terminal/SplitPaneView.tsx
@@ -25,7 +25,7 @@ function clampRatio(ratio: number): number {
 export function SplitPaneView({ node, renderLeaf, onRatioChange, onDragStateChange }: SplitPaneViewProps) {
   if (node.type === "leaf") {
     return (
-      <div className="h-full w-full min-w-0 min-h-0">
+      <div className="h-full w-full min-w-0 min-h-0 relative" data-slot-id={node.slotId}>
         {renderLeaf(node.slotId)}
       </div>
     );

--- a/src/hooks/useTerminalDragDrop.ts
+++ b/src/hooks/useTerminalDragDrop.ts
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import type { SessionSlot } from "@/components/terminal/PreLaunchCard";
+
+interface UseTerminalDragDropOptions {
+  slots: SessionSlot[];
+  onDrop: (sessionId: number, paths: string[]) => void;
+}
+
+interface UseTerminalDragDropResult {
+  /** Which pane slot is being hovered during a file drag */
+  dropTargetSlotId: string | null;
+  /** Whether an external file drag is active over the window */
+  isDraggingFiles: boolean;
+}
+
+/**
+ * Window-level drag-drop handler for files dragged from Finder/Explorer
+ * onto terminal panes.
+ *
+ * Uses Tauri's native `onDragDropEvent` which provides physical coordinates
+ * and file paths. Hit-tests against `[data-slot-id]` DOM elements to
+ * determine which pane the files are being dragged over.
+ */
+export function useTerminalDragDrop({
+  slots,
+  onDrop,
+}: UseTerminalDragDropOptions): UseTerminalDragDropResult {
+  const [dropTargetSlotId, setDropTargetSlotId] = useState<string | null>(null);
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+
+  // Build a lookup from slotId → sessionId for quick access
+  const slotSessionMap = useMemo(() => {
+    const map = new Map<string, number | null>();
+    for (const slot of slots) {
+      map.set(slot.id, slot.sessionId);
+    }
+    return map;
+  }, [slots]);
+
+  useEffect(() => {
+    const appWindow = getCurrentWindow();
+
+    /**
+     * Hit-test physical coordinates against `[data-slot-id]` elements.
+     * Tauri provides PhysicalPosition — divide by devicePixelRatio to get CSS pixels.
+     */
+    function findSlotAtPosition(physX: number, physY: number): string | null {
+      const scale = window.devicePixelRatio || 1;
+      const cssX = physX / scale;
+      const cssY = physY / scale;
+
+      const slotElements = document.querySelectorAll<HTMLElement>("[data-slot-id]");
+      for (const el of slotElements) {
+        const rect = el.getBoundingClientRect();
+        if (
+          cssX >= rect.left &&
+          cssX <= rect.right &&
+          cssY >= rect.top &&
+          cssY <= rect.bottom
+        ) {
+          return el.dataset.slotId ?? null;
+        }
+      }
+      return null;
+    }
+
+    const unlisten = appWindow.onDragDropEvent((event) => {
+      if (event.payload.type === "enter" || event.payload.type === "over") {
+        setIsDraggingFiles(true);
+        const pos = event.payload.position;
+        const slotId = findSlotAtPosition(pos.x, pos.y);
+        // Only highlight slots that have a launched session
+        if (slotId && slotSessionMap.get(slotId) !== null) {
+          setDropTargetSlotId(slotId);
+        } else {
+          setDropTargetSlotId(null);
+        }
+      } else if (event.payload.type === "drop") {
+        const pos = event.payload.position;
+        const slotId = findSlotAtPosition(pos.x, pos.y);
+        if (slotId) {
+          const sessionId = slotSessionMap.get(slotId);
+          if (sessionId !== null && sessionId !== undefined) {
+            onDrop(sessionId, event.payload.paths);
+          }
+        }
+        setDropTargetSlotId(null);
+        setIsDraggingFiles(false);
+      } else if (event.payload.type === "leave") {
+        setDropTargetSlotId(null);
+        setIsDraggingFiles(false);
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [slotSessionMap, onDrop]);
+
+  return { dropTargetSlotId, isDraggingFiles };
+}

--- a/src/lib/shellEscape.ts
+++ b/src/lib/shellEscape.ts
@@ -1,0 +1,14 @@
+/**
+ * Shell-escape file paths for safe pasting into a terminal.
+ *
+ * Uses POSIX single-quote wrapping: any internal single quotes are escaped
+ * as `'\''` (end quote, escaped quote, reopen quote).
+ */
+
+export function shellEscapePath(path: string): string {
+  return "'" + path.replace(/'/g, "'\\''") + "'";
+}
+
+export function shellEscapePaths(paths: string[]): string {
+  return paths.map(shellEscapePath).join(" ");
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -277,6 +277,23 @@
   background: rgb(var(--maestro-accent));
 }
 
+/* ── Drop Zone Overlay ── */
+.drop-zone-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(var(--maestro-accent) / 0.08);
+  border: 2px dashed rgb(var(--maestro-accent) / 0.5);
+  border-radius: 12px;
+  pointer-events: none;
+  color: rgb(var(--maestro-accent));
+  font-size: 13px;
+  font-weight: 500;
+}
+
 /* ── Terminal Cell Styling ── */
 
 .terminal-cell {


### PR DESCRIPTION
## Summary

- Adds drag & drop support for files from Finder/Explorer onto terminal panes, pasting shell-escaped paths at the cursor
- Uses Tauri's native `onDragDropEvent` API with hit-testing against terminal panes via `data-slot-id` DOM attributes
- Shows a visual drop zone overlay (dashed accent border) on the target pane during drag

## Details

**New files:**
- `src/lib/shellEscape.ts` — POSIX single-quote shell escaping (`'path'`, with internal `'` escaped as `'\''`)
- `src/hooks/useTerminalDragDrop.ts` — Window-level drag-drop listener that converts physical coordinates to CSS pixels, hit-tests `[data-slot-id]` elements, and calls `writeStdin()` on drop

**Modified files:**
- `src/components/terminal/SplitPaneView.tsx` — Added `data-slot-id` + `relative` to leaf wrapper div
- `src/components/terminal/TerminalGrid.tsx` — Wired hook, renders drop overlay in both normal and zoomed modes
- `src/styles/globals.css` — Drop zone overlay styles

**Edge cases handled:**
- Pre-launch cards: drops on unlaunched slots are ignored (no overlay shown)
- Multiple files: paths joined with spaces, each individually shell-escaped
- Paths with special chars: single-quote wrapping handles spaces, `$`, backticks, `"`, `\`, etc.
- Zoomed mode: zoomed terminal content div gets `data-slot-id` for hit-testing
- PhysicalPosition vs CSS pixels: coordinates divided by `devicePixelRatio`
- Cleanup: `unlisten` called on unmount

**Zero changes to:** `TerminalView.tsx`, Rust backend, Tauri capabilities, or `tauri.conf.json`

## Test plan

- [ ] Drag a single file from Finder onto a terminal → path appears at cursor, properly quoted
- [ ] Drag a file with spaces (e.g. `My Document.txt`) → appears as `'My Document.txt'`
- [ ] Drag multiple files → all paths appear space-separated
- [ ] Drag over different split panes → overlay shows only on the hovered pane
- [ ] Drag over a pre-launch card → no overlay, drop is ignored
- [ ] Drag files then move cursor away from window → overlay disappears
- [ ] Test in zoomed mode → drop works correctly
- [ ] `npm run build` passes with no type errors