### PR TITLE
fix(macos): add fullscreen menu item to enable Ctrl+Cmd+F shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,8 @@ pub fn run() {
                 .item(&zoom_out)
                 .separator()
                 .item(&zoom_reset)
+                .separator()
+                .fullscreen()
                 .build()?;
 
             // Window submenu (intentionally no Zoom/maximize item)


### PR DESCRIPTION
## Summary
- Added `.fullscreen()` to the View submenu in the macOS menu bar
- This enables the native `Ctrl+Cmd+F` keyboard shortcut for toggling fullscreen
- Previously, fullscreen only worked via the green traffic light button because the menu item was missing

## Test plan
- [ ] Build the app on macOS
- [ ] Verify `Ctrl+Cmd+F` toggles fullscreen mode
- [ ] Verify the green button still works as before
- [ ] Verify "Enter Full Screen" / "Exit Full Screen" appears in the View menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)