### PR TITLE
feat(status): detect working/idle from PTY output activity

### DIFF
--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -281,6 +281,15 @@ export const TerminalView = memo(function TerminalView({
     let rafId: number | null = null;
     let fallbackTimerId: ReturnType<typeof setTimeout> | null = null;
 
+    // === Activity-based status detection ===
+    let activityWorkingTimer: ReturnType<typeof setTimeout> | null = null;
+    let activityIdleTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastHeuristicStatus: string | null = null;
+
+    const MCP_GRACE_PERIOD_MS = 10_000; // Defer to MCP for 10s after last MCP update
+    const WORKING_DEBOUNCE_MS = 500;    // Sustained output before marking "Working"
+    const IDLE_TIMEOUT_MS = 5_000;      // No output before marking "Idle"
+
     const MAX_BUFFER_CHUNKS = 100;  // Force flush at ~400KB (100 × 4KB chunks)
     const FALLBACK_FLUSH_MS = 50;   // 20fps floor for backgrounded tabs
 
@@ -482,6 +491,36 @@ export const TerminalView = memo(function TerminalView({
         } else {
           scheduleFlush();
         }
+
+        // --- Activity-based status detection ---
+        const session = useSessionStore.getState().sessions.find(s => s.id === sessionId);
+        const lastMcp = session?.lastMcpUpdateTime ?? 0;
+        const mcpIsActive = (Date.now() - lastMcp) < MCP_GRACE_PERIOD_MS;
+
+        if (!mcpIsActive) {
+          // Debounce: set "Working" after sustained output
+          if (!activityWorkingTimer && lastHeuristicStatus !== "Working") {
+            activityWorkingTimer = setTimeout(() => {
+              activityWorkingTimer = null;
+              lastHeuristicStatus = "Working";
+              useSessionStore.getState().updateSession(sessionId, {
+                status: "Working" as BackendSessionStatus,
+              });
+            }, WORKING_DEBOUNCE_MS);
+          }
+
+          // Reset idle timer on every output chunk
+          if (activityIdleTimer) clearTimeout(activityIdleTimer);
+          activityIdleTimer = setTimeout(() => {
+            activityIdleTimer = null;
+            if (lastHeuristicStatus === "Working") {
+              lastHeuristicStatus = "Idle";
+              useSessionStore.getState().updateSession(sessionId, {
+                status: "Idle" as BackendSessionStatus,
+              });
+            }
+          }, IDLE_TIMEOUT_MS);
+        }
       });
       listenerReady
         .then((fn) => {
@@ -523,6 +562,8 @@ export const TerminalView = memo(function TerminalView({
     return () => {
       disposed = true;
       cancelPendingFlush();
+      if (activityWorkingTimer) clearTimeout(activityWorkingTimer);
+      if (activityIdleTimer) clearTimeout(activityIdleTimer);
       // Flush remaining buffered output before disposal
       if (term && writeBuffer.length > 0) {
         try { term.write(writeBuffer.join('')); } catch { /* ignore errors during cleanup */ }

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -41,6 +41,8 @@ export interface SessionConfig {
   project_path: string;
   statusMessage?: string;
   needsInputPrompt?: string;
+  /** Timestamp of the last MCP-driven status update (used by activity heuristic). */
+  lastMcpUpdateTime?: number;
 }
 
 /** Shape of the Tauri `session-status-changed` event payload. */
@@ -293,6 +295,7 @@ export const useSessionStore = create<SessionState>()((set, get) => ({
                       status,
                       statusMessage: message,
                       needsInputPrompt: needs_input_prompt,
+                      lastMcpUpdateTime: Date.now(),
                     }
                   : s
               ),


### PR DESCRIPTION
different states but showing the indicators now working:

<img width="544" height="97" alt="ClockerStatusItem_and_Item-0_and_bb3cc23c-6950-4e96-8b40-850e09f46934_and_Item-0_and_Item-0_and_Item-0_and_Battery_and_WiFi_and_Item-0_and_BentoBox_and_Clock" src="https://github.com/user-attachments/assets/55de886c-7d53-4f2f-94ce-d299d0631708" />

<img width="284" height="242" alt="Tauri_App" src="https://github.com/user-attachments/assets/0efa6de2-77ea-43a2-8305-15d3bc1d29af" />

## Summary

- Detects Claude's working/idle state from PTY output timing instead of relying on Claude to call an MCP tool (which it doesn't reliably do)
- Sustained terminal output for 500ms marks session as "Working", silence for 5s marks it as "Idle"
- MCP status updates still take priority when recent (10s grace period), so if MCP ever works it seamlessly overrides the heuristic

## Test plan

- [ ] Launch a session — status starts as "Starting" then settles to "Idle"
- [ ] Send a message to Claude — after ~500ms of streaming output, status changes to "Working"
- [ ] Claude finishes responding — after ~5s of silence, status returns to "Idle"
- [ ] Verify across multiple sessions — each session tracks activity independently
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)