### PR TITLE
fix(ui): return to idle view when closing last session

### DIFF
--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -208,6 +208,9 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
   const mounted = useRef(false);
   // Track debounce timers for saving branch config (keyed by slot ID)
   const branchConfigSaveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Ref to access latest onAllSessionsClosed without adding it to callback deps
+  const onAllSessionsClosedRef = useRef(onAllSessionsClosed);
+  onAllSessionsClosedRef.current = onAllSessionsClosed;
 
   // Stable per-slot focus callbacks — avoids creating new arrow functions on every render,
   // which would defeat React.memo on TerminalView.
@@ -721,24 +724,33 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
     const worktreePath = slot?.worktreePath;
     const workingDir = worktreePath || projectPath;
 
-    // Clean up cached focus callback for this slot
-    if (slot) {
-      focusCallbacksRef.current.delete(slot.id);
+    // If this is the last slot, return to idle landing view immediately
+    if (slotsRef.current.length <= 1 && onAllSessionsClosedRef.current) {
+      // Clean up focus callback
+      if (slot) {
+        focusCallbacksRef.current.delete(slot.id);
+      }
+      onAllSessionsClosedRef.current();
+    } else {
+      // Clean up cached focus callback for this slot
+      if (slot) {
+        focusCallbacksRef.current.delete(slot.id);
 
-      // If the closed pane was focused, focus its sibling
-      if (focusedSlotId === slot.id) {
-        const sibling = findSiblingSlotId(layoutTree, slot.id);
-        setFocusedSlotId(sibling);
+        // If the closed pane was focused, focus its sibling
+        if (focusedSlotId === slot.id) {
+          const sibling = findSiblingSlotId(layoutTree, slot.id);
+          setFocusedSlotId(sibling);
+        }
+
+        // Remove leaf from split tree
+        setLayoutTree((prev) => {
+          const result = removeLeaf(prev, slot.id);
+          return result ?? prev;
+        });
       }
 
-      // Remove leaf from split tree
-      setLayoutTree((prev) => {
-        const result = removeLeaf(prev, slot.id);
-        return result ?? prev; // shouldn't be null since we respawn below
-      });
+      setSlots((prev) => prev.filter((s) => s.sessionId !== sessionId));
     }
-
-    setSlots((prev) => prev.filter((s) => s.sessionId !== sessionId));
 
     // Remove session from the session store
     useSessionStore.getState().removeSession(sessionId);
@@ -776,6 +788,13 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
    */
   const removeSlot = useCallback((slotId: string) => {
     focusCallbacksRef.current.delete(slotId);
+
+    // If removing the last slot, return to idle landing view immediately
+    // rather than going through an intermediate empty state
+    if (slotsRef.current.length <= 1 && onAllSessionsClosedRef.current) {
+      onAllSessionsClosedRef.current();
+      return;
+    }
 
     // If the removed pane was focused, focus its sibling
     if (focusedSlotId === slotId) {


### PR DESCRIPTION
## Summary
- When closing the last pre-launch session card (X button) or killing the last running session, the app now returns directly to the idle landing view (plus button) instead of briefly clearing the screen
- Added `onAllSessionsClosedRef` to access the callback without adding it to useCallback deps
- Modified `removeSlot` and `handleKill` in TerminalGrid to call `onAllSessionsClosed()` directly when removing the last slot

## Test plan
- [ ] Open a project, click the plus button to enter grid view with a PreLaunchCard
- [ ] Click X on the PreLaunchCard - should return to idle view with plus button (not flash empty)
- [ ] Launch a session, then kill it - should return to idle view with plus button
- [ ] With 2+ sessions, close one - should stay in grid view with remaining session(s)
- [ ] With 2+ sessions, close all - last one should return to idle view

Fixes https://github.com/its-maestro-baby/maestro/issues/182