### PR TITLE
fix(git): re-check GitHub auth status after initial failure

### DIFF
--- a/src/components/git/GitGraphPanel.tsx
+++ b/src/components/git/GitGraphPanel.tsx
@@ -47,32 +47,19 @@ export function GitGraphPanel({
     clearSelectedDiscussion,
   } = useGitHubStore();
 
-  // Check auth and fetch data when tab changes or repo changes
+  // Re-check auth whenever user switches to a GitHub tab or repo changes
   useEffect(() => {
-    if (!repoPath) return;
+    if (!repoPath || activeTab === "commits") return;
+    checkAuth(repoPath);
+  }, [repoPath, activeTab, checkAuth]);
 
-    // Check auth status
-    if (!authStatus) {
-      checkAuth(repoPath);
-    }
-
-    // Fetch data for active tab
-    if (activeTab === "prs" && authStatus?.logged_in) {
-      fetchPullRequests(repoPath);
-    } else if (activeTab === "issues" && authStatus?.logged_in) {
-      fetchIssues(repoPath);
-    } else if (activeTab === "discussions" && authStatus?.logged_in) {
-      fetchDiscussions(repoPath);
-    }
-  }, [
-    repoPath,
-    activeTab,
-    authStatus,
-    checkAuth,
-    fetchPullRequests,
-    fetchIssues,
-    fetchDiscussions,
-  ]);
+  // Fetch data for active tab once authenticated
+  useEffect(() => {
+    if (!repoPath || !authStatus?.logged_in) return;
+    if (activeTab === "prs") fetchPullRequests(repoPath);
+    else if (activeTab === "issues") fetchIssues(repoPath);
+    else if (activeTab === "discussions") fetchDiscussions(repoPath);
+  }, [repoPath, activeTab, authStatus, fetchPullRequests, fetchIssues, fetchDiscussions]);
 
   // Handle PR selection
   const handleSelectPR = useCallback(
@@ -298,6 +285,13 @@ export function GitGraphPanel({
                   <p className="text-[10px] text-maestro-muted/40">
                     Run <code className="rounded bg-maestro-card px-1 py-0.5">gh auth login</code> in your terminal
                   </p>
+                  <button
+                    type="button"
+                    onClick={() => repoPath && checkAuth(repoPath)}
+                    className="mt-1 rounded bg-maestro-card px-3 py-1 text-xs text-maestro-muted/60 transition-colors hover:bg-maestro-border hover:text-maestro-text"
+                  >
+                    Retry
+                  </button>
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## Summary

- **Fixed** GitHub auth status never re-checking after initial failure — the `!authStatus` guard only passed when `null`, so once set to `{ logged_in: false }` the panel was permanently stuck on "Not authenticated"
- **Split** the single `useEffect` into two: an auth-check effect (triggers on tab switch) and a data-fetch effect (triggers when auth succeeds)
- **Added** a "Retry" button to the auth prompt so users can manually re-check without switching tabs

## Test plan

- [ ] Open a repo → go to PRs tab → see "Not authenticated" prompt
- [ ] Run `gh auth login` in terminal
- [ ] Switch tabs (e.g., Issues → PRs) → should now show authenticated content
- [ ] Click the "Retry" button → should detect auth and load data
- [ ] Verify commits tab still works normally (no unnecessary auth checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)