### PR TITLE
fix: window splits target wrong project tab

### DIFF
--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -291,6 +291,7 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
     onSplitVertical: useCallback(() => handleSplit("vertical"), [handleSplit]),
     onSplitHorizontal: useCallback(() => handleSplit("horizontal"), [handleSplit]),
     onClosePane: closePaneRef.current,
+    enabled: isActive,
   });
 
   // Sync refs with state and report counts to parent

--- a/src/hooks/useTerminalKeyboard.ts
+++ b/src/hooks/useTerminalKeyboard.ts
@@ -17,6 +17,8 @@ interface UseTerminalKeyboardOptions {
   onSplitHorizontal?: () => void;
   /** Callback to close the focused pane (Cmd+W) */
   onClosePane?: () => void;
+  /** Whether this keyboard handler is active (e.g. only for the active project tab) */
+  enabled?: boolean;
 }
 
 /**
@@ -43,8 +45,11 @@ export function useTerminalKeyboard({
   onSplitVertical,
   onSplitHorizontal,
   onClosePane,
+  enabled = true,
 }: UseTerminalKeyboardOptions): void {
   useEffect(() => {
+    if (!enabled) return;
+
     function handleKeyDown(event: KeyboardEvent) {
       const modifierKey = isMac() ? event.metaKey : event.ctrlKey;
       if (!modifierKey) return;
@@ -112,5 +117,5 @@ export function useTerminalKeyboard({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [terminalCount, focusedIndex, onFocusTerminal, onCycleNext, onCyclePrevious, onSplitVertical, onSplitHorizontal, onClosePane]);
+  }, [enabled, terminalCount, focusedIndex, onFocusTerminal, onCycleNext, onCyclePrevious, onSplitVertical, onSplitHorizontal, onClosePane]);
 }


### PR DESCRIPTION
## Human explanation 
if you had two projects, the tab commands were sent to the first project, not the current project tab open. This fixes that

## Summary
- Fixes Cmd+D / Cmd+Shift+D / Cmd+W targeting the first project tab instead of the active one when multiple projects are open
- Root cause: all `TerminalGrid` instances register global keydown listeners simultaneously (ZStack pattern), and the first tab's listener fires first
- Adds an `enabled` option to `useTerminalKeyboard` gated by `isActive`, so only the active project tab handles keyboard shortcuts

## Test plan
- [ ] Open two project tabs
- [ ] Switch to the second tab
- [ ] Press Cmd+D — verify the split happens on the second (active) tab, not the first
- [ ] Press Cmd+Shift+D — verify horizontal split targets active tab
- [ ] Press Cmd+W — verify close pane targets active tab
- [ ] Verify Cmd+1-9 terminal navigation only affects the active tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)