### PR TITLE
feat(git): add git fetch support for remotes

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -203,6 +203,23 @@ pub async fn git_refs_for_commit(
     git.refs_for_commit(&commit_hash).await
 }
 
+/// Fetches refs and objects from a specific remote.
+/// Uses --prune to clean up stale remote-tracking branches.
+#[tauri::command]
+pub async fn git_fetch(repo_path: String, remote_name: String) -> Result<(), GitError> {
+    validate_repo_path(&repo_path)?;
+    let git = Git::new(&repo_path);
+    git.fetch(&remote_name).await
+}
+
+/// Fetches refs and objects from all configured remotes.
+#[tauri::command]
+pub async fn git_fetch_all(repo_path: String) -> Result<(), GitError> {
+    validate_repo_path(&repo_path)?;
+    let git = Git::new(&repo_path);
+    git.fetch_all().await
+}
+
 /// Tests connectivity to a remote.
 /// Returns true if reachable, false otherwise.
 #[tauri::command]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -584,6 +584,32 @@ impl Git {
         }
     }
 
+    /// Fetches refs and objects from a specific remote.
+    ///
+    /// Uses `--prune` to remove stale remote-tracking branches that no longer
+    /// exist on the remote. Allows up to 120 seconds for large repositories.
+    pub async fn fetch(&self, remote_name: &str) -> Result<(), GitError> {
+        self.run_with_timeout(
+            &["fetch", "--prune", remote_name],
+            std::time::Duration::from_secs(120),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Fetches refs and objects from all configured remotes.
+    ///
+    /// Uses `--all --prune` to update every remote and clean up stale
+    /// remote-tracking branches. Allows up to 120 seconds.
+    pub async fn fetch_all(&self) -> Result<(), GitError> {
+        self.run_with_timeout(
+            &["fetch", "--all", "--prune"],
+            std::time::Duration::from_secs(120),
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Updates the URL of an existing remote.
     pub async fn set_remote_url(&self, name: &str, url: &str) -> Result<(), GitError> {
         self.run(&["remote", "set-url", name, url]).await?;

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -147,12 +147,22 @@ impl Git {
         }
     }
 
-    /// Executes a git subcommand and returns its captured output.
+    /// Executes a git subcommand with the default 30-second timeout.
     ///
     /// Returns `GitNotFound` if the git binary is missing, `SpawnError` for
     /// other I/O failures, and `CommandFailed` for non-zero exit codes.
     /// Both stdout and stderr are decoded as UTF-8 (returns `InvalidUtf8` on failure).
     pub async fn run(&self, args: &[&str]) -> Result<GitOutput, GitError> {
+        self.run_with_timeout(args, Duration::from_secs(30)).await
+    }
+
+    /// Like `run`, but with a caller-specified timeout for long-running
+    /// operations such as `git fetch`.
+    pub async fn run_with_timeout(
+        &self,
+        args: &[&str],
+        timeout_duration: Duration,
+    ) -> Result<GitOutput, GitError> {
         let mut cmd = Command::new("git");
         cmd.arg("-C")
             .arg(&self.repo_path)
@@ -191,12 +201,13 @@ impl Git {
         }
 
         let command_str = format!("git -C {} {}", self.repo_path.display(), args.join(" "));
+        let timeout_secs = timeout_duration.as_secs();
 
-        let output = timeout(Duration::from_secs(30), cmd.output())
+        let output = timeout(timeout_duration, cmd.output())
             .await
             .map_err(|_| GitError::CommandFailed {
                 code: -1,
-                stderr: format!("Command timed out after 30s: {}", command_str),
+                stderr: format!("Command timed out after {timeout_secs}s: {command_str}"),
                 command: command_str.clone(),
             })?
             .map_err(|source| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -200,6 +200,8 @@ pub fn run() {
             commands::git::git_add_remote,
             commands::git::git_remove_remote,
             commands::git::git_refs_for_commit,
+            commands::git::git_fetch,
+            commands::git::git_fetch_all,
             commands::git::git_test_remote,
             commands::git::git_set_remote_url,
             commands::git::git_get_default_branch,

--- a/src/components/git/GitSettingsModal.tsx
+++ b/src/components/git/GitSettingsModal.tsx
@@ -1,5 +1,6 @@
 import {
   Check,
+  Download,
   Edit2,
   FolderGit2,
   FolderSearch,
@@ -291,8 +292,10 @@ function RepositoryDiscoverySection({ repoPath, tabId }: { repoPath: string; tab
 /* ── Remotes Section ── */
 
 function RemotesSection({ repoPath }: { repoPath: string }) {
-  const { remotes, remoteStatuses, fetchRemotes, addRemote, removeRemote, setRemoteUrl, testRemote, testAllRemotes } =
-    useGitStore();
+  const {
+    remotes, remoteStatuses, fetchRemotes, addRemote, removeRemote, setRemoteUrl,
+    testRemote, testAllRemotes, fetchRemoteRefs, fetchAllRemoteRefs, isFetching, fetchingRemotes,
+  } = useGitStore();
   const [showAdd, setShowAdd] = useState(false);
   const [newName, setNewName] = useState("");
   const [newUrl, setNewUrl] = useState("");
@@ -315,10 +318,13 @@ function RemotesSection({ repoPath }: { repoPath: string }) {
     if (!newName.trim() || !newUrl.trim()) return;
     setAdding(true);
     try {
-      await addRemote(repoPath, newName.trim(), newUrl.trim());
+      const remoteName = newName.trim();
+      await addRemote(repoPath, remoteName, newUrl.trim());
       setNewName("");
       setNewUrl("");
       setShowAdd(false);
+      // Auto-fetch the new remote so its branches appear immediately
+      fetchRemoteRefs(repoPath, remoteName).catch(() => {});
     } catch {
       // Error logged in store
     } finally {
@@ -362,6 +368,19 @@ function RemotesSection({ repoPath }: { repoPath: string }) {
           Remotes
         </h3>
         <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => fetchAllRemoteRefs(repoPath).catch(() => {})}
+            disabled={isFetching}
+            className="rounded p-1 hover:bg-maestro-border/40 disabled:opacity-50"
+            title="Fetch all remotes"
+          >
+            {isFetching ? (
+              <Loader2 size={12} className="text-maestro-muted animate-spin" />
+            ) : (
+              <Download size={12} className="text-maestro-muted" />
+            )}
+          </button>
           <button
             type="button"
             onClick={() => testAllRemotes(repoPath)}
@@ -428,6 +447,19 @@ function RemotesSection({ repoPath }: { repoPath: string }) {
                   <RemoteStatusIndicator status={remoteStatuses[remote.name] ?? "unknown"} />
                   <span className="text-xs font-semibold text-maestro-text">{remote.name}</span>
                   <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      type="button"
+                      onClick={() => fetchRemoteRefs(repoPath, remote.name).catch(() => {})}
+                      disabled={!!fetchingRemotes[remote.name]}
+                      className="rounded p-1 hover:bg-maestro-border/40 disabled:opacity-50"
+                      title="Fetch remote"
+                    >
+                      {fetchingRemotes[remote.name] ? (
+                        <Loader2 size={10} className="text-maestro-muted animate-spin" />
+                      ) : (
+                        <Download size={10} className="text-maestro-muted" />
+                      )}
+                    </button>
                     <button
                       type="button"
                       onClick={() => testRemote(repoPath, remote.name)}

--- a/src/stores/useGitStore.ts
+++ b/src/stores/useGitStore.ts
@@ -78,6 +78,10 @@ interface GitState {
   remoteStatuses: Record<string, RemoteStatus>;
   defaultBranch: string | null;
 
+  // Fetch state
+  isFetching: boolean;
+  fetchingRemotes: Record<string, boolean>;
+
   // Loading/error state
   isLoading: boolean;
   isLoadingMore: boolean;
@@ -103,6 +107,8 @@ interface GitState {
   setRemoteUrl: (repoPath: string, name: string, url: string) => Promise<void>;
   testRemote: (repoPath: string, remoteName: string) => Promise<void>;
   testAllRemotes: (repoPath: string) => Promise<void>;
+  fetchRemoteRefs: (repoPath: string, remoteName: string) => Promise<void>;
+  fetchAllRemoteRefs: (repoPath: string) => Promise<void>;
   fetchDefaultBranch: (repoPath: string) => Promise<void>;
   setDefaultBranch: (repoPath: string, branch: string, global?: boolean) => Promise<void>;
   getCommitFiles: (repoPath: string, commitHash: string) => Promise<FileChange[]>;
@@ -123,6 +129,8 @@ export const useGitStore = create<GitState>()((set, get) => ({
   remotes: [],
   remoteStatuses: {},
   defaultBranch: null,
+  isFetching: false,
+  fetchingRemotes: {},
   isLoading: false,
   isLoadingMore: false,
   error: null,
@@ -334,6 +342,34 @@ export const useGitStore = create<GitState>()((set, get) => ({
     await Promise.all(remotes.map((remote) => get().testRemote(repoPath, remote.name)));
   },
 
+  fetchRemoteRefs: async (repoPath: string, remoteName: string) => {
+    set((state) => ({
+      fetchingRemotes: { ...state.fetchingRemotes, [remoteName]: true },
+    }));
+    try {
+      await invoke("git_fetch", { repoPath, remoteName });
+    } catch (err) {
+      console.error(`Failed to fetch remote '${remoteName}':`, err);
+      throw err;
+    } finally {
+      set((state) => ({
+        fetchingRemotes: { ...state.fetchingRemotes, [remoteName]: false },
+      }));
+    }
+  },
+
+  fetchAllRemoteRefs: async (repoPath: string) => {
+    set({ isFetching: true });
+    try {
+      await invoke("git_fetch_all", { repoPath });
+    } catch (err) {
+      console.error("Failed to fetch all remotes:", err);
+      throw err;
+    } finally {
+      set({ isFetching: false });
+    }
+  },
+
   fetchDefaultBranch: async (repoPath: string) => {
     try {
       const defaultBranch = await invoke<string | null>("git_get_default_branch", { repoPath });
@@ -382,6 +418,8 @@ export const useGitStore = create<GitState>()((set, get) => ({
       remotes: [],
       remoteStatuses: {},
       defaultBranch: null,
+      isFetching: false,
+      fetchingRemotes: {},
       isLoading: false,
       isLoadingMore: false,
       error: null,


### PR DESCRIPTION
## Human Summary
If you add a remote or open the new session screen, it fetches your remote branches so your list is up to date

## Summary
- Add `git fetch` backend support (per-remote and fetch-all) with `--prune` and 120s timeout
- Add Fetch All button and per-remote fetch buttons in Git Settings > Remotes
- Auto-fetch after adding a remote so its branches appear immediately in the branch selector

## Test plan
- [ ] Add a new remote in Git Settings > Remotes — verify its branches appear in the "Add Session" branch dropdown without manual intervention
- [ ] Click the per-remote fetch button (download icon) — verify spinner shows and remote branches update
- [ ] Click "Fetch All" button in Remotes header — verify all remotes are fetched with spinner
- [ ] Verify fetch errors (e.g. unreachable remote) surface gracefully without crashing

Fixes https://github.com/its-maestro-baby/maestro/issues/185

🤖 Generated with [Claude Code](https://claude.com/claude-code)