### PR TITLE
fix: clear orphaned sessions from SessionManager on cleanup

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -267,14 +267,27 @@ pub async fn save_pasted_image(data: Vec<u8>, media_type: String) -> Result<Stri
     Ok(path.to_string_lossy().into_owned())
 }
 
-/// Kills all active PTY sessions.
+/// Kills all active PTY sessions and clears the session registry.
 ///
 /// Used to clean up orphaned sessions when the frontend reloads.
-/// Returns the number of sessions that were killed.
+/// Clears both PTY processes (ProcessManager) and session metadata
+/// (SessionManager) to prevent stale "idle" sessions from appearing
+/// in the sidebar after a page reload.
+/// Returns the number of PTY sessions that were killed.
 #[tauri::command]
-pub async fn kill_all_sessions(state: State<'_, ProcessManager>) -> Result<u32, PtyError> {
+pub async fn kill_all_sessions(
+    state: State<'_, ProcessManager>,
+    session_state: State<'_, SessionManager>,
+) -> Result<u32, PtyError> {
     let pm = state.inner().clone();
-    pm.kill_all_sessions().await
+    let killed = pm.kill_all_sessions().await?;
+    let cleared = session_state.clear_all();
+    log::info!(
+        "Cleanup: killed {} PTY session(s), cleared {} session entries",
+        killed,
+        cleared
+    );
+    Ok(killed)
 }
 
 /// Checks if a command is available in the user's PATH.

--- a/src-tauri/src/core/session_manager.rs
+++ b/src-tauri/src/core/session_manager.rs
@@ -137,6 +137,14 @@ impl SessionManager {
             .collect()
     }
 
+    /// Removes all sessions. Returns the number of sessions that were cleared.
+    /// Used to clean up stale session entries when the frontend reloads.
+    pub fn clear_all(&self) -> usize {
+        let count = self.sessions.len();
+        self.sessions.clear();
+        count
+    }
+
     /// Removes all sessions for a project. Returns the removed configs.
     /// Useful when closing a project tab.
     pub fn remove_sessions_for_project(&self, project_path: &str) -> Vec<SessionConfig> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,8 +72,10 @@ function App() {
     }
   }, []);
 
-  // Clean up orphaned PTY sessions on mount (e.g., after page reload)
-  // This ensures no stale processes remain from the previous frontend state
+  // Clean up orphaned PTY sessions on mount, then fetch fresh session state.
+  // kill_all_sessions clears both ProcessManager (PTYs) and SessionManager
+  // (metadata), so fetchSessions must run AFTER cleanup completes to avoid
+  // loading stale "idle" sessions from a previous frontend lifecycle.
   useEffect(() => {
     invoke<number>("kill_all_sessions")
       .then((count) => {
@@ -83,14 +85,12 @@ function App() {
       })
       .catch((err) => {
         console.error("Failed to clean up orphaned sessions:", err);
+      })
+      .finally(() => {
+        fetchSessions().catch((err) => {
+          console.error("Failed to fetch sessions:", err);
+        });
       });
-  }, []);
-
-  // Initialize session store: fetch initial state and subscribe to events
-  useEffect(() => {
-    fetchSessions().catch((err) => {
-      console.error("Failed to fetch sessions:", err);
-    });
 
     const unlistenPromise = initListeners().catch((err) => {
       console.error("Failed to initialize listeners:", err);

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -396,6 +396,8 @@ export const TerminalGrid = forwardRef<TerminalGridHandle, TerminalGridProps>(fu
         for (const slot of slotsRef.current) {
           if (slot.sessionId !== null) {
             killSession(slot.sessionId).catch(console.error);
+            // Also remove from session store to prevent orphaned entries
+            useSessionStore.getState().removeSession(slot.sessionId);
           }
         }
       }

--- a/src/stores/useWorkspaceStore.ts
+++ b/src/stores/useWorkspaceStore.ts
@@ -221,8 +221,9 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
       closeTab: (id: string) => {
         const tabToClose = get().tabs.find((t) => t.id === id);
 
-        // Kill all sessions belonging to this project (fire-and-forget)
+        // Kill all sessions belonging to this project and remove from backend
         if (tabToClose && tabToClose.sessionIds.length > 0) {
+          // Kill PTY processes
           Promise.allSettled(tabToClose.sessionIds.map((sessionId) => killSession(sessionId)))
             .then((results) => {
               for (const result of results) {
@@ -231,6 +232,9 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
                 }
               }
             });
+          // Remove sessions from backend SessionManager to prevent orphan accumulation
+          invoke("remove_sessions_for_project", { projectPath: tabToClose.projectPath })
+            .catch((err: unknown) => console.error("Failed to remove sessions on tab close:", err));
         }
 
         const remaining = get().tabs.filter((t) => t.id !== id);


### PR DESCRIPTION
## Summary
- **Root cause**: Multiple code paths killed PTY processes (`ProcessManager`) but never removed the corresponding session metadata from `SessionManager`, causing phantom "idle" sessions to accumulate in the sidebar
- `kill_all_sessions` now clears both `ProcessManager` and `SessionManager`, and `fetchSessions` is sequenced after cleanup to avoid race conditions
- `closeTab` and `TerminalGrid` unmount now properly remove sessions from the backend/store

## Test plan
- [ ] Launch multiple sessions, reload the page (Cmd+R) — sidebar should show 0 sessions after reload
- [ ] Launch sessions, close the project tab, reopen — no stale idle sessions should appear
- [ ] Launch sessions, use "Stop All" — verify sessions are fully cleaned up (regression check)
- [ ] Verify `cargo test` passes for session_manager and status_server tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)