### PR TITLE
feat: add CLI command to open Maestro from terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,9 +2676,11 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-cli",
  "tauri-plugin-dialog",
  "tauri-plugin-macos-permissions",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tempfile",
@@ -4970,6 +4999,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-cli"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e78fb2c09a81546bcd376d34db4bda5769270d00990daa9f0d6e7ac1107e25"
+dependencies = [
+ "clap",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,6 +5089,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/cli/maestro.sh
+++ b/cli/maestro.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Maestro CLI — launch Maestro from the terminal
+# Usage: maestro [path]
+#
+# Examples:
+#   maestro              # Launch/focus Maestro
+#   maestro .            # Open current directory as a project
+#   maestro /path/to/dir # Open a specific project path
+
+if [ -n "$1" ]; then
+    # Resolve to absolute path
+    if [ -d "$1" ]; then
+        PATH_ARG="$(cd "$1" && pwd)"
+    else
+        PATH_ARG="$1"
+    fi
+
+    case "$(uname -s)" in
+        Darwin)
+            open -a Maestro --args "$PATH_ARG"
+            ;;
+        Linux)
+            MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+            "$MAESTRO_BIN" "$PATH_ARG" &
+            disown
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            start "" "Maestro.exe" "$PATH_ARG"
+            ;;
+        *)
+            echo "Unsupported platform: $(uname -s)" >&2
+            exit 1
+            ;;
+    esac
+else
+    case "$(uname -s)" in
+        Darwin)
+            open -a Maestro
+            ;;
+        Linux)
+            MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+            "$MAESTRO_BIN" &
+            disown
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            start "" "Maestro.exe"
+            ;;
+        *)
+            echo "Unsupported platform: $(uname -s)" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/cli/maestro.sh
+++ b/cli/maestro.sh
@@ -7,47 +7,56 @@
 #   maestro .            # Open current directory as a project
 #   maestro /path/to/dir # Open a specific project path
 
-if [ -n "$1" ]; then
-    # Resolve to absolute path
+resolve_path() {
     if [ -d "$1" ]; then
-        PATH_ARG="$(cd "$1" && pwd)"
+        (cd "$1" && pwd)
     else
-        PATH_ARG="$1"
+        echo "$1"
     fi
+}
 
-    case "$(uname -s)" in
-        Darwin)
-            open -a Maestro --args "$PATH_ARG"
-            ;;
-        Linux)
-            MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+launch_macos() {
+    # Try bundle identifier first (most reliable)
+    if open -b com.maestro.app "$@" 2>/dev/null; then
+        return 0
+    fi
+    # Fall back to app name
+    if open -a Maestro "$@" 2>/dev/null; then
+        return 0
+    fi
+    echo "Error: Maestro.app not found. Is it installed?" >&2
+    return 1
+}
+
+case "$(uname -s)" in
+    Darwin)
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
+            launch_macos --args "$PATH_ARG"
+        else
+            launch_macos
+        fi
+        ;;
+    Linux)
+        MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
             "$MAESTRO_BIN" "$PATH_ARG" &
-            disown
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
-            start "" "Maestro.exe" "$PATH_ARG"
-            ;;
-        *)
-            echo "Unsupported platform: $(uname -s)" >&2
-            exit 1
-            ;;
-    esac
-else
-    case "$(uname -s)" in
-        Darwin)
-            open -a Maestro
-            ;;
-        Linux)
-            MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+        else
             "$MAESTRO_BIN" &
-            disown
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
+        fi
+        disown
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
+            start "" "Maestro.exe" "$PATH_ARG"
+        else
             start "" "Maestro.exe"
-            ;;
-        *)
-            echo "Unsupported platform: $(uname -s)" >&2
-            exit 1
-            ;;
-    esac
-fi
+        fi
+        ;;
+    *)
+        echo "Unsupported platform: $(uname -s)" >&2
+        exit 1
+        ;;
+esac

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,9 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-cli = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,8 @@
     "store:default",
     "dialog:default",
     "opener:default",
-    "updater:default"
+    "updater:default",
+    "cli:default",
+    "core:window:allow-set-focus"
   ]
 }

--- a/src-tauri/src/commands/cli.rs
+++ b/src-tauri/src/commands/cli.rs
@@ -4,40 +4,59 @@ const CLI_SCRIPT: &str = r#"#!/bin/bash
 # Maestro CLI — launch Maestro from the terminal
 # Usage: maestro [path]
 
-if [ -n "$1" ]; then
-    # Resolve to absolute path
+resolve_path() {
     if [ -d "$1" ]; then
-        PATH_ARG="$(cd "$1" && pwd)"
+        (cd "$1" && pwd)
     else
-        PATH_ARG="$1"
+        echo "$1"
     fi
+}
 
-    case "$(uname -s)" in
-        Darwin)
-            open -a Maestro --args "$PATH_ARG"
-            ;;
-        Linux)
-            maestro-app "$PATH_ARG" &
-            disown
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
+launch_macos() {
+    # Try bundle identifier first (most reliable)
+    if open -b com.maestro.app "$@" 2>/dev/null; then
+        return 0
+    fi
+    # Fall back to app name
+    if open -a Maestro "$@" 2>/dev/null; then
+        return 0
+    fi
+    echo "Error: Maestro.app not found. Is it installed?" >&2
+    return 1
+}
+
+case "$(uname -s)" in
+    Darwin)
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
+            launch_macos --args "$PATH_ARG"
+        else
+            launch_macos
+        fi
+        ;;
+    Linux)
+        MAESTRO_BIN="${MAESTRO_BIN:-maestro-app}"
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
+            "$MAESTRO_BIN" "$PATH_ARG" &
+        else
+            "$MAESTRO_BIN" &
+        fi
+        disown
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        if [ -n "$1" ]; then
+            PATH_ARG="$(resolve_path "$1")"
             start "" "Maestro.exe" "$PATH_ARG"
-            ;;
-    esac
-else
-    case "$(uname -s)" in
-        Darwin)
-            open -a Maestro
-            ;;
-        Linux)
-            maestro-app &
-            disown
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
+        else
             start "" "Maestro.exe"
-            ;;
-    esac
-fi
+        fi
+        ;;
+    *)
+        echo "Unsupported platform: $(uname -s)" >&2
+        exit 1
+        ;;
+esac
 "#;
 
 fn cli_install_path() -> PathBuf {

--- a/src-tauri/src/commands/cli.rs
+++ b/src-tauri/src/commands/cli.rs
@@ -55,36 +55,147 @@ fn cli_install_path() -> PathBuf {
 pub fn install_cli() -> Result<String, String> {
     let dest = cli_install_path();
 
-    // Ensure parent directory exists
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {e}"))?;
+    // Try direct write first
+    match try_install_cli_direct(&dest) {
+        Ok(()) => return Ok(dest.to_string_lossy().to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            // Fall through to elevated install
+        }
+        Err(e) => return Err(format!("Failed to install CLI: {e}")),
     }
 
-    std::fs::write(&dest, CLI_SCRIPT).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            "Permission denied. On macOS/Linux, you may need to run with sudo or ensure /usr/local/bin is writable.".to_string()
-        } else {
-            format!("Failed to write CLI script: {e}")
-        }
-    })?;
+    // Use elevated permissions (osascript on macOS, pkexec on Linux)
+    install_cli_elevated(&dest)?;
+    Ok(dest.to_string_lossy().to_string())
+}
 
-    // Make executable on Unix
+fn try_install_cli_direct(dest: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(dest, CLI_SCRIPT)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
-            .map_err(|e| format!("Failed to set permissions: {e}"))?;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
+fn install_cli_elevated(dest: &std::path::Path) -> Result<(), String> {
+    // Write script to a temp file first, then move with elevated privileges
+    let tmp = std::env::temp_dir().join("maestro-cli-install.sh");
+    std::fs::write(&tmp, CLI_SCRIPT)
+        .map_err(|e| format!("Failed to write temp file: {e}"))?;
+
+    let dest_str = dest.to_string_lossy();
+
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            "do shell script \"install -m 755 '{}' '{}'\" with administrator privileges",
+            tmp.to_string_lossy(),
+            dest_str
+        );
+        let output = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .output()
+            .map_err(|e| format!("Failed to run osascript: {e}"))?;
+
+        let _ = std::fs::remove_file(&tmp);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("User canceled") || stderr.contains("-128") {
+                return Err("Installation cancelled by user.".to_string());
+            }
+            return Err(format!("Failed to install: {stderr}"));
+        }
     }
 
-    Ok(dest.to_string_lossy().to_string())
+    #[cfg(target_os = "linux")]
+    {
+        let output = std::process::Command::new("pkexec")
+            .arg("install")
+            .arg("-m")
+            .arg("755")
+            .arg(tmp.to_string_lossy().as_ref())
+            .arg(dest_str.as_ref())
+            .output()
+            .map_err(|e| format!("Failed to run pkexec: {e}"))?;
+
+        let _ = std::fs::remove_file(&tmp);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Failed to install: {stderr}"));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let _ = std::fs::remove_file(&tmp);
+        // On Windows the direct write should work since we install to user-local dir
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
 pub fn uninstall_cli() -> Result<(), String> {
     let dest = cli_install_path();
-    if dest.exists() {
-        std::fs::remove_file(&dest).map_err(|e| format!("Failed to remove CLI: {e}"))?;
+    if !dest.exists() {
+        return Ok(());
     }
+
+    // Try direct removal first
+    match std::fs::remove_file(&dest) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            // Fall through to elevated removal
+        }
+        Err(e) => return Err(format!("Failed to remove CLI: {e}")),
+    }
+
+    let dest_str = dest.to_string_lossy();
+
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            "do shell script \"rm -f '{}'\" with administrator privileges",
+            dest_str
+        );
+        let output = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .output()
+            .map_err(|e| format!("Failed to run osascript: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("User canceled") || stderr.contains("-128") {
+                return Err("Uninstall cancelled by user.".to_string());
+            }
+            return Err(format!("Failed to uninstall: {stderr}"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let output = std::process::Command::new("pkexec")
+            .arg("rm")
+            .arg("-f")
+            .arg(dest_str.as_ref())
+            .output()
+            .map_err(|e| format!("Failed to run pkexec: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Failed to uninstall: {stderr}"));
+        }
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/commands/cli.rs
+++ b/src-tauri/src/commands/cli.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+
+const CLI_SCRIPT: &str = r#"#!/bin/bash
+# Maestro CLI — launch Maestro from the terminal
+# Usage: maestro [path]
+
+if [ -n "$1" ]; then
+    # Resolve to absolute path
+    if [ -d "$1" ]; then
+        PATH_ARG="$(cd "$1" && pwd)"
+    else
+        PATH_ARG="$1"
+    fi
+
+    case "$(uname -s)" in
+        Darwin)
+            open -a Maestro --args "$PATH_ARG"
+            ;;
+        Linux)
+            maestro-app "$PATH_ARG" &
+            disown
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            start "" "Maestro.exe" "$PATH_ARG"
+            ;;
+    esac
+else
+    case "$(uname -s)" in
+        Darwin)
+            open -a Maestro
+            ;;
+        Linux)
+            maestro-app &
+            disown
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            start "" "Maestro.exe"
+            ;;
+    esac
+fi
+"#;
+
+fn cli_install_path() -> PathBuf {
+    if cfg!(target_os = "windows") {
+        // On Windows, install to the user's local bin
+        directories::BaseDirs::new()
+            .map(|d| d.data_local_dir().join("Maestro").join("maestro.cmd"))
+            .unwrap_or_else(|| PathBuf::from("C:\\Program Files\\Maestro\\maestro.cmd"))
+    } else {
+        PathBuf::from("/usr/local/bin/maestro")
+    }
+}
+
+#[tauri::command]
+pub fn install_cli() -> Result<String, String> {
+    let dest = cli_install_path();
+
+    // Ensure parent directory exists
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {e}"))?;
+    }
+
+    std::fs::write(&dest, CLI_SCRIPT).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            "Permission denied. On macOS/Linux, you may need to run with sudo or ensure /usr/local/bin is writable.".to_string()
+        } else {
+            format!("Failed to write CLI script: {e}")
+        }
+    })?;
+
+    // Make executable on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("Failed to set permissions: {e}"))?;
+    }
+
+    Ok(dest.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub fn uninstall_cli() -> Result<(), String> {
+    let dest = cli_install_path();
+    if dest.exists() {
+        std::fs::remove_file(&dest).map_err(|e| format!("Failed to remove CLI: {e}"))?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn is_cli_installed() -> bool {
+    cli_install_path().exists()
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod cli;
 pub mod claudemd;
 pub mod fonts;
 pub mod git;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use tauri::menu::{MenuBuilder, MenuItem, SubmenuBuilder};
 use tauri::{Emitter, Manager};
+use tauri_plugin_cli::CliExt;
+use std::path::PathBuf;
 
 use core::marketplace_manager::MarketplaceManager;
 use core::mcp_manager::McpManager;
@@ -33,6 +35,20 @@ pub fn run() {
     log::info!("Maestro starting up...");
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_cli::init())
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            // A second instance was launched with these args — forward to existing window
+            if let Some(path) = args.get(1) {
+                let resolved = resolve_cli_path(path);
+                if let Some(p) = resolved {
+                    let _ = app.emit("cli-open-project", p.to_string_lossy().to_string());
+                }
+            }
+            // Focus the existing window
+            if let Some(w) = app.get_webview_window("main") {
+                let _ = w.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -167,6 +183,24 @@ pub fn run() {
 
             app.manage(event_bus);
             app.manage(transcript_watcher);
+
+            // Handle CLI arguments on initial launch
+            if let Ok(matches) = app.cli().matches() {
+                if let Some(path_arg) = matches.args.get("path") {
+                    if let Some(path_str) = path_arg.value.as_str() {
+                        if !path_str.is_empty() {
+                            if let Some(resolved) = resolve_cli_path(path_str) {
+                                let handle = app.handle().clone();
+                                // Emit after a short delay so the frontend has time to mount
+                                tauri::async_runtime::spawn(async move {
+                                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                                    let _ = handle.emit("cli-open-project", resolved.to_string_lossy().to_string());
+                                });
+                            }
+                        }
+                    }
+                }
+            }
 
             Ok(())
         })
@@ -310,9 +344,26 @@ pub fn run() {
             // Hooks commands
             commands::hooks::write_session_hooks_config,
             commands::hooks::remove_session_hooks_config,
+            // CLI commands
+            commands::cli::install_cli,
+            commands::cli::uninstall_cli,
+            commands::cli::is_cli_installed,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Maestro");
+}
+
+/// Resolve a CLI path argument to an absolute path.
+/// Handles ".", "..", relative paths, and already-absolute paths.
+fn resolve_cli_path(path: &str) -> Option<PathBuf> {
+    let p = PathBuf::from(path);
+    let absolute = if p.is_absolute() {
+        p
+    } else {
+        std::env::current_dir().ok()?.join(p)
+    };
+    // Canonicalize to resolve ".." etc, but fall back to the joined path if it doesn't exist yet
+    Some(absolute.canonicalize().unwrap_or(absolute))
 }
 
 // Note: We intentionally don't check git availability at startup.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,6 +27,16 @@
     }
   },
   "plugins": {
+    "cli": {
+      "args": [
+        {
+          "name": "path",
+          "index": 1,
+          "takesValue": true,
+          "required": false
+        }
+      ]
+    },
     "updater": {
       "endpoints": [
         "https://github.com/its-maestro-baby/maestro/releases/latest/download/latest.json"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { GitFork, RefreshCw, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getDeduplicatedCurrentBranch } from "@/lib/git";
@@ -135,6 +137,21 @@ function App() {
     });
     return () => {
       stopActivityListener();
+    };
+  }, []);
+
+  // Listen for CLI-initiated project open events (from `maestro /path`)
+  useEffect(() => {
+    const openProject = useWorkspaceStore.getState().openProject;
+    const unlisten = listen<string>("cli-open-project", (event) => {
+      const path = event.payload;
+      if (path) {
+        openProject(path);
+        getCurrentWindow().setFocus();
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
     };
   }, []);
 

--- a/src/components/settings/MaestroSettingsModal.tsx
+++ b/src/components/settings/MaestroSettingsModal.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Loader2,
   RefreshCw,
+  Terminal,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -40,6 +41,8 @@ export function MaestroSettingsModal({ onClose }: MaestroSettingsModalProps) {
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [endpointInput, setEndpointInput] = useState("");
+  const [cliInstalled, setCliInstalled] = useState<boolean | null>(null);
+  const [cliStatus, setCliStatus] = useState<string | null>(null);
 
   const status = useUpdateStore((s) => s.status);
   const lastCheckedAt = useUpdateStore((s) => s.lastCheckedAt);
@@ -50,6 +53,10 @@ export function MaestroSettingsModal({ onClose }: MaestroSettingsModalProps) {
   const setAutoCheckEnabled = useUpdateStore((s) => s.setAutoCheckEnabled);
   const setCheckInterval = useUpdateStore((s) => s.setCheckInterval);
   const setCustomEndpoint = useUpdateStore((s) => s.setCustomEndpoint);
+
+  useEffect(() => {
+    invoke<boolean>("is_cli_installed").then(setCliInstalled).catch(() => setCliInstalled(false));
+  }, []);
 
   useEffect(() => {
     invoke<string>("get_app_version")
@@ -194,6 +201,65 @@ export function MaestroSettingsModal({ onClose }: MaestroSettingsModalProps) {
                 </select>
               </div>
             )}
+          </div>
+
+          {/* CLI Command */}
+          <div>
+            <div className="mb-1.5 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-maestro-muted">
+              <Terminal size={13} className="text-maestro-accent" />
+              CLI Command
+            </div>
+            <div className="space-y-1.5 px-1">
+              <p className="text-[11px] text-maestro-muted">
+                Install the <code className="rounded bg-maestro-border/40 px-1 py-0.5 text-maestro-text">maestro</code> command to open projects from your terminal.
+              </p>
+              {cliStatus && (
+                <div className={`text-[11px] ${cliStatus.startsWith("Error") ? "text-maestro-red" : "text-maestro-green"}`}>
+                  {cliStatus}
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                {cliInstalled ? (
+                  <>
+                    <div className="flex items-center gap-1.5 text-[11px] text-maestro-green">
+                      <Check size={11} />
+                      Installed
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setCliStatus(null);
+                        invoke("uninstall_cli")
+                          .then(() => {
+                            setCliInstalled(false);
+                            setCliStatus("CLI command removed");
+                          })
+                          .catch((err) => setCliStatus(`Error: ${err}`));
+                      }}
+                      className="rounded px-2 py-0.5 text-[11px] text-maestro-red hover:bg-maestro-border/40"
+                    >
+                      Uninstall
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCliStatus(null);
+                      invoke<string>("install_cli")
+                        .then((path) => {
+                          setCliInstalled(true);
+                          setCliStatus(`Installed to ${path}`);
+                        })
+                        .catch((err) => setCliStatus(`Error: ${err}`));
+                    }}
+                    className="rounded border border-maestro-accent/50 bg-maestro-accent/10 px-3 py-1 text-[11px] font-medium text-maestro-accent hover:bg-maestro-accent/20"
+                  >
+                    Install &apos;maestro&apos; command in PATH
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
 
           {/* Advanced */}


### PR DESCRIPTION
## Summary

- Add `maestro` CLI command to open projects from the terminal (`maestro .`, `maestro /path`), similar to VS Code's `code` command
- Integrate `tauri-plugin-cli` for native argument parsing and `tauri-plugin-single-instance` to forward args to an already-running instance
- Add "Install CLI Command" button in Settings with elevated permission support (macOS password prompt)

## How it works

1. User runs `maestro /path/to/project` from terminal
2. Shell script launches the app via `open -b com.maestro.app --args` (macOS)
3. Tauri CLI plugin parses the path argument
4. If Maestro is already running, single-instance plugin forwards args to existing window
5. Frontend receives `cli-open-project` event and opens the project tab

## Test plan

- [x] Build succeeds (release + dev)
- [x] App launches normally with new plugins
- [x] Single-instance works — second launch forwards args to running instance
- [x] `maestro .` opens current directory as project
- [x] Settings UI shows "Install CLI Command" with admin password prompt
- [x] Bundle identifier lookup (`open -b com.maestro.app`) works reliably

Fixes #181