### PR TITLE
fix(git-panel): resolve "Not Authenticated with GitHub" on macOS GUI launch

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -302,41 +302,12 @@ pub async fn kill_all_sessions(
 pub async fn check_cli_available(command: String) -> Result<bool, String> {
     #[cfg(unix)]
     {
-        // Search for command in PATH and common installation directories
-        // We avoid spawning a shell because shell plugins (oh-my-zsh, powerlevel10k)
-        // can hang or abort when run without a TTY
-        let mut paths: Vec<String> = Vec::new();
+        // Search the augmented PATH (env PATH + common install dirs missed by
+        // GUI launchers). We avoid spawning a shell because shell plugins
+        // (oh-my-zsh, powerlevel10k) can hang or abort when run without a TTY.
+        use crate::core::cli_path::augmented_path;
 
-        // Start with current environment PATH
-        if let Ok(env_path) = std::env::var("PATH") {
-            paths.extend(env_path.split(':').map(String::from));
-        }
-
-        // Add common user installation directories that GUI launchers often miss
-        if let Ok(home) = std::env::var("HOME") {
-            // Homebrew on Apple Silicon
-            paths.push("/opt/homebrew/bin".to_string());
-            paths.push("/opt/homebrew/sbin".to_string());
-            // Homebrew on Intel Mac
-            paths.push("/usr/local/bin".to_string());
-            paths.push("/usr/local/sbin".to_string());
-            // npm global installations
-            paths.push(format!("{}/.npm-global/bin", home));
-            paths.push(format!("{}/node_modules/.bin", home));
-            // Cargo/Rust
-            paths.push(format!("{}/.cargo/bin", home));
-            // Go
-            paths.push(format!("{}/go/bin", home));
-            // Python user installs
-            paths.push(format!("{}/.local/bin", home));
-            // pyenv
-            paths.push(format!("{}/.pyenv/shims", home));
-            // rbenv
-            paths.push(format!("{}/.rbenv/shims", home));
-        }
-
-        // Search for command in all PATH directories
-        for dir in &paths {
+        for dir in augmented_path().split(':').filter(|s| !s.is_empty()) {
             let cmd_path = format!("{}/{}", dir, command);
             if std::path::Path::new(&cmd_path).exists() {
                 log::debug!("Found {} at {}", command, cmd_path);

--- a/src-tauri/src/core/cli_path.rs
+++ b/src-tauri/src/core/cli_path.rs
@@ -1,0 +1,84 @@
+//! PATH augmentation for CLI subprocesses spawned from the GUI.
+//!
+//! macOS apps launched from Finder/Dock/Spotlight inherit a minimal PATH from
+//! launchd (typically `/usr/bin:/bin:/usr/sbin:/sbin`), which does not include
+//! Homebrew, user installs, or most language toolchains. This causes
+//! `Command::new("gh")` (and similar) to fail with `ErrorKind::NotFound` even
+//! when the binary is installed. Linux has the same symptom when a DE launcher
+//! runs with a restricted PATH.
+//!
+//! `augmented_path()` returns a PATH string combining the inherited PATH with
+//! the common install directories, so subprocesses can find their executables.
+
+#[cfg(unix)]
+use std::sync::OnceLock;
+
+/// Returns a PATH value that merges the process's inherited PATH with common
+/// install directories missed by macOS/Linux GUI launchers.
+///
+/// The result is cached for the lifetime of the process.
+#[cfg(unix)]
+pub fn augmented_path() -> &'static str {
+    static CACHED: OnceLock<String> = OnceLock::new();
+    CACHED.get_or_init(build_augmented_path)
+}
+
+#[cfg(unix)]
+fn build_augmented_path() -> String {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    let mut parts: Vec<String> = if inherited.is_empty() {
+        Vec::new()
+    } else {
+        inherited.split(':').map(String::from).collect()
+    };
+
+    let mut extras: Vec<String> = vec![
+        "/opt/homebrew/bin".to_string(),
+        "/opt/homebrew/sbin".to_string(),
+        "/usr/local/bin".to_string(),
+        "/usr/local/sbin".to_string(),
+    ];
+
+    if let Ok(home) = std::env::var("HOME") {
+        extras.push(format!("{home}/.npm-global/bin"));
+        extras.push(format!("{home}/node_modules/.bin"));
+        extras.push(format!("{home}/.cargo/bin"));
+        extras.push(format!("{home}/go/bin"));
+        extras.push(format!("{home}/.local/bin"));
+        extras.push(format!("{home}/.pyenv/shims"));
+        extras.push(format!("{home}/.rbenv/shims"));
+    }
+
+    for dir in extras {
+        if !parts.iter().any(|p| p == &dir) {
+            parts.push(dir);
+        }
+    }
+
+    parts.join(":")
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn augmented_path_includes_common_dirs() {
+        let path = augmented_path();
+        assert!(path.contains("/opt/homebrew/bin"));
+        assert!(path.contains("/usr/local/bin"));
+    }
+
+    #[test]
+    fn augmented_path_preserves_inherited_entries() {
+        let inherited = std::env::var("PATH").unwrap_or_default();
+        let path = augmented_path();
+        for entry in inherited.split(':').filter(|s| !s.is_empty()) {
+            assert!(
+                path.split(':').any(|p| p == entry),
+                "expected inherited entry {entry:?} in augmented PATH"
+            );
+        }
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod claude_event;
+pub mod cli_path;
 pub mod error;
 pub mod event_bus;
 pub mod transcript_parser;

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -4,6 +4,8 @@ use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
 use super::error::GitError;
+#[cfg(unix)]
+use crate::core::cli_path::augmented_path;
 use crate::core::windows_process::TokioCommandExt;
 
 /// Resolves the `SSH_AUTH_SOCK` path for SSH-based git operations.
@@ -171,6 +173,13 @@ impl Git {
             .env("LC_ALL", "C")
             .kill_on_drop(true)
             .hide_console_window();
+
+        // macOS/Linux GUI launchers start the app with a minimal PATH that
+        // excludes Homebrew and user installs. Xcode CLT's `/usr/bin/git`
+        // usually works, but Homebrew-git (or git configured helpers that
+        // shell out) can be missing — augment PATH for consistency.
+        #[cfg(unix)]
+        cmd.env("PATH", augmented_path());
 
         // Ensure the SSH agent socket is reachable so that SSH-based remotes
         // (git@github.com:…) can authenticate without interactive prompts.

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -3,6 +3,8 @@ use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
 use super::error::GitHubError;
+#[cfg(unix)]
+use crate::core::cli_path::augmented_path;
 use crate::core::windows_process::TokioCommandExt;
 
 /// Captured stdout/stderr from a completed gh subprocess.
@@ -62,6 +64,12 @@ impl GitHub {
             .env("NO_COLOR", "1")
             .kill_on_drop(true)
             .hide_console_window();
+
+        // macOS/Linux GUI launchers start the app with a minimal PATH that
+        // excludes Homebrew and user installs, so `gh` often isn't resolvable
+        // even when installed. Inject the augmented PATH here.
+        #[cfg(unix)]
+        cmd.env("PATH", augmented_path());
 
         let command_str = format!("gh {}", args.join(" "));
 

--- a/src/components/git/GitGraphPanel.tsx
+++ b/src/components/git/GitGraphPanel.tsx
@@ -1,4 +1,4 @@
-import { GitFork, AlertCircle, Terminal } from "lucide-react";
+import { GitFork, AlertCircle, Loader2, Terminal } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import type { GraphNode } from "../../lib/graphLayout";
 import { useGitStore } from "../../stores/useGitStore";
@@ -40,6 +40,8 @@ export function GitGraphPanel({
   const { checkoutBranch, createBranch } = useGitStore();
   const {
     authStatus,
+    authError,
+    isCheckingAuth,
     pullRequests,
     issues,
     prsError,
@@ -195,8 +197,13 @@ export function GitGraphPanel({
   const openPRCount = pullRequests.filter((pr) => pr.state === "OPEN").length;
   const openIssueCount = issues.filter((i) => i.state === "OPEN").length;
 
-  // Check for gh CLI not installed or not authenticated
-  const isGhError = prsError?.includes("gh") || prsError?.includes("GitHub CLI");
+  // Check for gh CLI not installed. The auth check itself surfaces this via
+  // `authError` (since `prsError` is never populated while unauthenticated).
+  const ghMissingPattern = /gh\b|github cli|not found/i;
+  const hasGhError =
+    (authError != null && ghMissingPattern.test(authError)) ||
+    (prsError != null && ghMissingPattern.test(prsError));
+  const isGhError = activeTab !== "commits" && hasGhError;
   const showAuthPrompt =
     activeTab !== "commits" && authStatus && !authStatus.logged_in;
 
@@ -307,9 +314,13 @@ export function GitGraphPanel({
                   <button
                     type="button"
                     onClick={() => repoPath && checkAuth(repoPath)}
-                    className="mt-1 rounded bg-maestro-card px-3 py-1 text-xs text-maestro-muted/60 transition-colors hover:bg-maestro-border hover:text-maestro-text"
+                    disabled={isCheckingAuth}
+                    className="mt-1 flex items-center gap-1.5 rounded bg-maestro-card px-3 py-1 text-xs text-maestro-muted/60 transition-colors hover:bg-maestro-border hover:text-maestro-text disabled:cursor-not-allowed disabled:opacity-60"
                   >
-                    Retry
+                    {isCheckingAuth && (
+                      <Loader2 size={12} className="animate-spin" />
+                    )}
+                    {isCheckingAuth ? "Checking..." : "Retry"}
                   </button>
                 </div>
               </div>

--- a/src/components/git/GitGraphPanel.tsx
+++ b/src/components/git/GitGraphPanel.tsx
@@ -197,9 +197,10 @@ export function GitGraphPanel({
   const openPRCount = pullRequests.filter((pr) => pr.state === "OPEN").length;
   const openIssueCount = issues.filter((i) => i.state === "OPEN").length;
 
-  // Check for gh CLI not installed. The auth check itself surfaces this via
-  // `authError` (since `prsError` is never populated while unauthenticated).
-  const ghMissingPattern = /gh\b|github cli|not found/i;
+  // Check for gh CLI not installed. Matches the canonical `GhNotFound` Display
+  // string from the backend; avoids matching unrelated "not found" errors like
+  // `PullRequestNotFound` / `IssueNotFound` that also flow through as strings.
+  const ghMissingPattern = /github cli \(gh\) not found/i;
   const hasGhError =
     (authError != null && ghMissingPattern.test(authError)) ||
     (prsError != null && ghMissingPattern.test(prsError));

--- a/src/stores/__tests__/useGitHubStore.auth.test.ts
+++ b/src/stores/__tests__/useGitHubStore.auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+import { useGitHubStore } from "../useGitHubStore";
+
+function resetStore() {
+  useGitHubStore.getState().reset();
+}
+
+describe("useGitHubStore authError handling", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    resetStore();
+  });
+
+  it("populates authError when the auth check throws", async () => {
+    const err = "GitHub CLI (gh) not found. Install it from https://cli.github.com";
+    invokeMock.mockRejectedValueOnce(err);
+
+    await useGitHubStore.getState().checkAuth("/repo");
+
+    const state = useGitHubStore.getState();
+    expect(state.authError).toBe(err);
+    expect(state.authStatus).toEqual({ logged_in: false, username: null, scopes: [] });
+    expect(state.isCheckingAuth).toBe(false);
+  });
+
+  it("clears authError on a successful auth check", async () => {
+    useGitHubStore.setState({ authError: "stale error" });
+    invokeMock.mockResolvedValueOnce({
+      logged_in: true,
+      username: "octocat",
+      scopes: ["repo"],
+    });
+
+    await useGitHubStore.getState().checkAuth("/repo");
+
+    expect(useGitHubStore.getState().authError).toBeNull();
+  });
+
+  it("clears authError at the start of a new auth check", async () => {
+    useGitHubStore.setState({ authError: "stale error" });
+    let observedDuringCheck: string | null | undefined;
+    invokeMock.mockImplementationOnce(() => {
+      observedDuringCheck = useGitHubStore.getState().authError;
+      return Promise.resolve({ logged_in: true, username: null, scopes: [] });
+    });
+
+    await useGitHubStore.getState().checkAuth("/repo");
+
+    expect(observedDuringCheck).toBeNull();
+  });
+
+  it("clears authError on reset()", () => {
+    useGitHubStore.setState({ authError: "some error" });
+
+    useGitHubStore.getState().reset();
+
+    expect(useGitHubStore.getState().authError).toBeNull();
+  });
+});

--- a/src/stores/useGitHubStore.ts
+++ b/src/stores/useGitHubStore.ts
@@ -132,6 +132,8 @@ interface GitHubState {
   // Authentication
   authStatus: AuthStatus | null;
   isCheckingAuth: boolean;
+  /** Error from the most recent auth check (e.g., `gh` binary missing). */
+  authError: string | null;
 
   // Pull requests
   pullRequests: PullRequestInfo[];
@@ -207,6 +209,7 @@ export const useGitHubStore = create<GitHubState>()((set, get) => ({
   // Initial state
   authStatus: null,
   isCheckingAuth: false,
+  authError: null,
   pullRequests: [],
   prFilter: "open",
   isPRsLoading: false,
@@ -227,17 +230,18 @@ export const useGitHubStore = create<GitHubState>()((set, get) => ({
   isLoadingDiscussionDetail: false,
 
   checkAuth: async (repoPath: string) => {
-    set({ isCheckingAuth: true });
+    set({ isCheckingAuth: true, authError: null });
     try {
       const authStatus = await invoke<AuthStatus>("github_auth_status", {
         repoPath,
       });
-      set({ authStatus, isCheckingAuth: false });
+      set({ authStatus, isCheckingAuth: false, authError: null });
     } catch (err) {
       console.error("Failed to check GitHub auth:", err);
       set({
         authStatus: { logged_in: false, username: null, scopes: [] },
         isCheckingAuth: false,
+        authError: String(err),
       });
     }
   },
@@ -448,6 +452,7 @@ export const useGitHubStore = create<GitHubState>()((set, get) => ({
     set({
       authStatus: null,
       isCheckingAuth: false,
+      authError: null,
       pullRequests: [],
       prFilter: "open",
       isPRsLoading: false,


### PR DESCRIPTION
## Summary

- Augment the subprocess PATH for `gh` and `git` on Unix so macOS Finder/Dock/Spotlight launches can find Homebrew-installed binaries (root cause of the bogus "Not Authenticated" state).
- Track `authError` in `useGitHubStore` and show the correct "GitHub CLI not found" prompt when the auth check itself fails (previously unreachable because `prsError` is only set while authenticated).
- Give the Retry button a spinner + disabled state tied to `isCheckingAuth` so retries are visibly responsive.

## Why

Symptom reported: the GitHub tabs of the git panel show "Not Authenticated with GitHub" and the Retry button feels dead.

Root cause chain:
1. Tauri GUI launches on macOS inherit a minimal launchd PATH (e.g. `/usr/bin:/bin:/usr/sbin:/sbin`). Homebrew's `/opt/homebrew/bin/gh` isn't in it, so `Command::new("gh")` fails with `ErrorKind::NotFound` → `GitHubError::GhNotFound`.
2. `useGitHubStore.checkAuth` caught every error as `{ logged_in: false }` with no detail.
3. `GitGraphPanel` only inspected `prsError` to decide whether to show the "GitHub CLI not found" prompt. `prsError` is only populated by `fetchPullRequests`, which is gated on `authStatus.logged_in === true` — unreachable from a failed auth check. So every gh failure collapsed into the generic "Not Authenticated" overlay.
4. Retry called the same `checkAuth` which hit the same `GhNotFound` path with no spinner — visually unchanged, so it felt like the button did nothing.

The existing `check_cli_available` command already knows about the macOS GUI PATH issue and searches common install dirs. This PR applies the same pattern to the `gh` and `git` subprocess runners by injecting an augmented PATH.

## Changes

- `src-tauri/src/core/cli_path.rs` (new) — `augmented_path()` helper merging the inherited PATH with common install dirs (Homebrew, `~/.cargo/bin`, `~/.local/bin`, pyenv/rbenv shims, etc.). Cached for process lifetime. Includes unit tests.
- `src-tauri/src/github/runner.rs` — set `PATH=augmented_path()` on every `gh` subprocess (unix only).
- `src-tauri/src/git/runner.rs` — same, for consistency and for systems where git lives under Homebrew.
- `src/stores/useGitHubStore.ts` — add `authError: string | null`, populate it in the `checkAuth` catch block, reset on new checks and on `reset()`.
- `src/components/git/GitGraphPanel.tsx` — route "gh not found" prompt off `authError` (or `prsError`), scope to non-commits tabs so it never hides the commit graph, and show a `Loader2` + "Checking..." label on the Retry button while `isCheckingAuth`.

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo test --lib core::cli_path` — 2/2 passing
- [x] `npx tsc --noEmit` — 0 errors
- [x] Launch the app from Finder on macOS (Homebrew `gh` installed + authenticated) → GitHub tabs load PRs/Issues/Discussions without the auth overlay.
- [x] Uninstall/hide `gh` → the panel shows the "GitHub CLI not found" prompt (not the auth prompt).
- [x] With `gh` installed but logged out → "Not authenticated" prompt shows; clicking Retry visibly transitions to "Checking..." then back.
- [x] Commits tab still renders when a GitHub tab previously errored.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>